### PR TITLE
test(#8): add integration tests for facilitator and refactor client

### DIFF
--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -15,7 +15,7 @@ func newRefactorCmd(params *Params) *cobra.Command {
 		Short:   "refactor code",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("refactor command called with provider: %s", params.provider)
-			ref, err := client.Refactor("code refactoring...")
+			ref, err := client.Refactor(client.NewMockProject())
 			log.Debug("refactor result: %s", ref)
 			fmt.Println("Refrax says:", ref)
 			return err

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -1,0 +1,67 @@
+package client
+
+type Project interface {
+	Classes() ([]JavaClass, error)
+}
+
+type JavaClass interface {
+	Name() string
+	Content() string
+	SetContent(content string)
+}
+
+type InMemoryProject struct {
+	files map[string]JavaClass
+}
+
+type InMemoryJavaClass struct {
+	name    string
+	content string
+}
+
+func NewMockProject() Project {
+	mapping := map[string]string{
+		"Main.java": "public class Main {\n\tpublic static void main(String[] args) {\n\t\tString m = \"Hello, World\";\n\t\tSystem.out.println(m);\n\t}\n}\n",
+	}
+	return NewInMemoryProject(mapping)
+}
+
+func SingleClassProject(name, content string) Project {
+	mapping := map[string]string{
+		name: content,
+	}
+	return NewInMemoryProject(mapping)
+}
+
+func NewInMemoryProject(files map[string]string) Project {
+	res := make(map[string]JavaClass, len(files))
+	for name, content := range files {
+		res[name] = &InMemoryJavaClass{
+			name:    name,
+			content: content,
+		}
+	}
+	return &InMemoryProject{
+		files: res,
+	}
+}
+
+func (i *InMemoryProject) Classes() ([]JavaClass, error) {
+	res := make([]JavaClass, 0)
+	for _, class := range i.files {
+		res = append(res, class)
+	}
+	return res, nil
+}
+
+func (i *InMemoryJavaClass) SetContent(content string) {
+	i.content = content
+}
+
+func (i *InMemoryJavaClass) Content() string {
+	return i.content
+}
+
+func (i *InMemoryJavaClass) Name() string {
+	return i.name
+}

--- a/internal/client/refrax-client.go
+++ b/internal/client/refrax-client.go
@@ -1,20 +1,39 @@
 package client
 
 import (
+	"encoding/base64"
+	"fmt"
 	"io"
 
 	"github.com/cqfn/refrax/internal/critic"
 	"github.com/cqfn/refrax/internal/facilitator"
+	"github.com/cqfn/refrax/internal/log"
+	"github.com/cqfn/refrax/internal/protocol"
 )
 
-func Refactor(question string) (string, error) {
+type RefraxClient struct {
+	client protocol.Client
+}
+
+func NewRefraxClient() *RefraxClient {
+	return &RefraxClient{
+		client: protocol.NewCustomClient("http://localhost:8080"),
+	}
+}
+
+func Refactor(proj Project) (Project, error) {
+	return NewRefraxClient().Refactor(proj)
+}
+
+func (c *RefraxClient) Refactor(proj Project) (Project, error) {
+	log.Debug("starting refactoring for project %s", proj)
 	facilitator, err := facilitator.NewFacilitator("none", 8080)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	critic, err := critic.NewCritic("none", 8081)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	fready := make(chan struct{})
 	cready := make(chan struct{})
@@ -24,15 +43,42 @@ func Refactor(question string) (string, error) {
 	<-fready
 	<-cready
 
-	// Do some job
-
+	all, err := proj.Classes()
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("found %d classes in the project: %v", len(all), all)
+	for _, class := range all {
+		log.Debug("sending class %s for refactoring", class.Name())
+		resp, err := c.client.SendMessage(protocol.MessageSendParams{
+			Message: protocol.Message{
+				MessageID: "1",
+				Parts: protocol.Parts{
+					&protocol.TextPart{
+						Text: fmt.Sprintf("Refactor the class '%s'", class.Name()),
+						Kind: protocol.PartKindText,
+					}, &protocol.FilePart{
+						Kind: protocol.PartKindFile,
+						File: protocol.FileWithBytes{
+							Bytes: base64.StdEncoding.EncodeToString([]byte(class.Content())),
+						},
+					},
+				},
+			}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to send message for class %s: %w", class.Name(), err)
+		}
+		refactored := resp.Result.(protocol.Message).Parts[0].(*protocol.FilePart).File.(protocol.FileWithBytes).Bytes
+		decoded, err := base64.StdEncoding.DecodeString(refactored)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode refactored class %s: %w", class.Name(), err)
+		}
+		class.SetContent(string(decoded))
+		log.Info("client refactored the class %s: %s", class.Name(), class.Content())
+	}
 	defer closeResource(critic, &err)
 	defer closeResource(facilitator, &err)
-
-	// This function is a placeholder for the actual implementation.
-	// In a real-world scenario, this would send the question to the server
-	// and return the response.
-	return "This is a mock response to the question: " + question, nil
+	return proj, err
 }
 
 func startServer(server *facilitator.Facilitator, ready chan struct{}, err *error) {

--- a/internal/client/refrax-client_test.go
+++ b/internal/client/refrax-client_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/cqfn/refrax/internal/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefraxClient_Creates_Successfully(t *testing.T) {
+	client := NewRefraxClient()
+	assert.NotNil(t, client, "Refrax client should not be nil")
+}
+
+func TestRefraxClient_Refactors_Successfully(t *testing.T) {
+	client := NewRefraxClient()
+
+	result, err := client.Refactor(SingleClassProject("Main.java", beforeRefactor))
+
+	log.Debug("Refactored project: %s", result)
+	require.NoError(t, err, "Expected no error during refactoring")
+	classes, err := result.Classes()
+	require.NoError(t, err, "Expected no error retrieving classes from refactored project")
+	class := classes[0]
+	assert.Equal(t, "Main.java", class.Name(), "Class name should match")
+	assert.Equal(t, afterRefactor, class.Content(), "Class content should match expected refactored content")
+}
+
+const (
+	beforeRefactor = `public class Main {
+	public static void main(String[] args) {
+		String m = "Hello, World";
+		System.out.println(m);
+	}
+}
+`
+
+	afterRefactor = `public class Main {
+	public static void main(String[] args) {
+		System.out.println("Hello, World");
+	}
+`
+)

--- a/internal/protocol/custom-client.go
+++ b/internal/protocol/custom-client.go
@@ -25,6 +25,7 @@ func NewCustomClient(url string) Client {
 func (c *CustomClient) SendMessage(params MessageSendParams) (*JSONRPCResponse, error) {
 	req := JSONRPCRequest{
 		JSONRPC: "2.0",
+		ID:      "1", // Static ID for simplicity, can be changed to a unique ID generator
 		Method:  "message/send",
 		Params:  params,
 	}

--- a/internal/protocol/custom-client_test.go
+++ b/internal/protocol/custom-client_test.go
@@ -1,0 +1,35 @@
+package protocol
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomClient_SendsMessage(t *testing.T) {
+	var err error
+	serv, port, ready := testServer(t)
+	closeResource(serv, &err)
+	<-ready
+	client := NewCustomClient(fmt.Sprintf("http://localhost:%d", port))
+	message := MessageSendParams{
+		Message: tellJoke(),
+	}
+
+	resp, err := client.SendMessage(message)
+
+	expected := &JSONRPCResponse{
+		ID:      "1",
+		JSONRPC: "2.0",
+		Result:  joke(),
+	}
+	require.NoError(t, err, "Failed to send message")
+	require.NotNil(t, resp, "Response should not be nil")
+	require.Equal(t, expected, resp, "Response text should match")
+
+	// response, err := client.SendMessage(message)
+	// require.NoError(t, err, "Failed to send message")
+	// assert.NotNil(t, response, "Response should not be nil")
+	// assert.Equal(t, "Hello, world!", response.Result.Parts[0]["text"], "Response text should match")
+}

--- a/internal/protocol/custom-server_test.go
+++ b/internal/protocol/custom-server_test.go
@@ -22,14 +22,9 @@ var testAgentCard = AgentCard{
 }
 
 func TestCustomServer_AgentCard(t *testing.T) {
-	card := testAgentCard
-	port, err := freePort()
-	require.NoError(t, err, "Failed to get a free port")
-	server, err := NewCustomServer(card, jokeHandler, port)
-	require.NoError(t, err, "Failed to create custom server")
-	ready := make(chan struct{})
-	go startServer(server, ready, &err)
-	defer closeResource(server, &err)
+	var err error
+	serv, port, ready := testServer(t)
+	defer closeResource(serv, &err)
 	<-ready
 
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/.well-known/agent-card.json", port))
@@ -45,53 +40,48 @@ func TestCustomServer_AgentCard(t *testing.T) {
 }
 
 func TestCustomServer_SendsMessage(t *testing.T) {
+	var err error
+	serv, port, ready := testServer(t)
+	defer closeResource(serv, &err)
+	<-ready
+	request := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "message/send",
+		Params: map[string]any{
+			"message":  tellJoke(),
+			"metadata": map[string]any{},
+		},
+	}
+	body, err := json.Marshal(request)
+	require.NoError(t, err, "Failed to marshal request body")
+
+	resp, err := http.Post(fmt.Sprintf("http://localhost:%d/", port), "application/json", bytes.NewBuffer(body))
+
+	require.NoError(t, err)
+	defer closeResource(resp.Body, &err)
+	var response JSONRPCResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	require.NoError(t, err, "Failed to decode response body")
+	expected := JSONRPCResponse{
+		ID:      "1",
+		JSONRPC: "2.0",
+		Result:  joke(),
+	}
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"), "Content-Type header should be application/json")
+	assert.Equal(t, expected, response, "Server should return the expected joke message")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func testServer(t *testing.T) (Server, int, chan struct{}) {
+	t.Helper()
 	port, err := freePort()
 	require.NoError(t, err, "Failed to get a free port")
 	server, err := NewCustomServer(testAgentCard, jokeHandler, port)
 	require.NoError(t, err, "Failed to create custom server")
 	ready := make(chan struct{})
 	go startServer(server, ready, &err)
-	defer closeResource(server, &err)
-	<-ready
-
-	payload := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  "message/send",
-		"params": map[string]any{
-			"message": map[string]any{
-				"role": "user",
-				"parts": []map[string]any{
-					{
-						"kind": "text",
-						"text": "tell me a joke",
-					},
-				},
-				"messageId": "9229e770-767c-417b-a0b0-f0741243c589",
-			},
-			"metadata": map[string]any{},
-		},
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		panic(err)
-	}
-
-	resp, err := http.Post(fmt.Sprintf("http://localhost:%d/", port), "application/json", bytes.NewBuffer(body))
-
-	require.NoError(t, err)
-	defer closeResource(resp.Body, &err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"), "Content-Type header should be application/json")
-	bodyBytes, err := io.ReadAll(resp.Body)
-	require.NoError(t, err, "Failed to read response body")
-	jsonresp := string(bodyBytes)
-	require.NoError(t, err, "Failed to decode JSON-RPC response")
-	log.Debug("JSON-RPC response: %v", jsonresp)
-	require.NoError(t, err, "Failed to decode JSON-RPC response")
-	assert.Contains(t, jsonresp, `"jsonrpc":"2.0"`, "Response should contain JSON-RPC version")
-	assert.Contains(t, jsonresp, `"text":"Why did the chicken cross the road? To get to the other side!"`, "Response should contain joke text")
-	assert.Contains(t, jsonresp, `"messageId":"363422be-b0f9-4692-a24d-278670e7c7f1"`, "Response should contain message ID")
+	return server, port, ready
 }
 
 func startServer(server Server, ready chan struct{}, err *error) {
@@ -107,21 +97,68 @@ func closeResource(resource io.Closer, err *error) {
 }
 
 func jokeHandler(msg *Message) (*Message, error) {
+	// log.Debug("Received message: %s", msg.MessageID)
+	// if len(msg.Parts) == 0 || msg.Parts[0]["text"] != "tell me a joke" {
+	// 	return nil, fmt.Errorf("unexpected message content, we expected 'tell me a joke', got: '%v'", msg.Parts[0]["text"])
+	// }
+	// response := joke()
+	// return &response, nil
 	log.Debug("Received message: %s", msg.MessageID)
-	if len(msg.Parts) == 0 || msg.Parts[0]["text"] != "tell me a joke" {
-		return nil, fmt.Errorf("unexpected message content")
+	if len(msg.Parts) == 0 || msg.Parts[0].PartKind() != PartKindText || msg.Parts[0].(*TextPart).Text != "tell me a joke" {
+		return nil, fmt.Errorf("unexpected message content, we expected 'tell me a joke', got: '%v'", msg.Parts[0].(*TextPart).Text)
 	}
-	response := &Message{
+	response := joke()
+	return &response, nil
+}
+
+func tellJoke() Message {
+	// return Message{
+	// 	Role: "user",
+	// 	Parts: []map[string]any{
+	// 		{
+	// 			"kind": "text",
+	// 			"text": "tell me a joke",
+	// 		},
+	// 	},
+	// 	MessageID: "9229e770-767c-417b-a0b0-f0741243c589",
+	// 	Kind:  KindMessage,
+	// }
+	return Message{
+		Role: "user",
+		Parts: []Part{
+			&TextPart{
+				Kind: PartKindText,
+				Text: "tell me a joke",
+			},
+		},
+		MessageID: "9229e770-767c-417b-a0b0-f0741243c589",
+		Kind:      KindMessage,
+	}
+}
+
+func joke() Message {
+	// return Message{
+	// 	Role: "agent",
+	// 	Parts: []map[string]any{
+	// 		{
+	// 			"kind": "text",
+	// 			"text": "Why did the chicken cross the road? To get to the other side!",
+	// 		},
+	// 	},
+	// 	MessageID: "363422be-b0f9-4692-a24d-278670e7c7f1",
+	// 	Kind:  KindMessage,
+	// }
+	return Message{
 		Role: "agent",
-		Parts: []map[string]any{
-			{
-				"kind": "text",
-				"text": "Why did the chicken cross the road? To get to the other side!",
+		Parts: []Part{
+			&TextPart{
+				Kind: PartKindText,
+				Text: "Why did the chicken cross the road? To get to the other side!",
 			},
 		},
 		MessageID: "363422be-b0f9-4692-a24d-278670e7c7f1",
+		Kind:      KindMessage,
 	}
-	return response, nil
 }
 
 func freePort() (int, error) {

--- a/internal/protocol/jsonrpc_test.go
+++ b/internal/protocol/jsonrpc_test.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONRPCResponse_UnmarshalMessage(t *testing.T) {
+	before := JSONRPCResponse{
+		ID: float64(1),
+		Result: Message{
+			Role: "agent",
+			Parts: []Part{
+				&TextPart{
+					Kind: PartKindText,
+					Text: "Why did the chicken cross the road? To get to the other side!",
+				},
+			},
+			MessageID: "363422be-b0f9-4692-a24d-278670e7c7f1",
+			Kind:      KindMessage,
+		},
+	}
+	var after JSONRPCResponse
+
+	data, err := json.Marshal(before)
+
+	require.NoError(t, err, "Failed to marshal JSONRPCResponse")
+	err = json.Unmarshal(data, &after)
+	require.NoError(t, err, "Failed to unmarshal JSONRPCResponse")
+	assert.Equal(t, before, after, "data structures should match")
+}
+
+func TestJSONRPCResponse_UnmarshalTask(t *testing.T) {
+	before := JSONRPCResponse{
+		ID: float64(1),
+		Result: Task{
+			ID:   "12345",
+			Kind: KindTask,
+			Status: TaskStatus{
+				State: TaskStateCompleted,
+			},
+		},
+	}
+	var after JSONRPCResponse
+	data, err := json.Marshal(before)
+	require.NoError(t, err, "Failed to marshal JSONRPCResponse")
+
+	err = json.Unmarshal(data, &after)
+
+	require.NoError(t, err, "Failed to unmarshal JSONRPCResponse")
+	assert.Equal(t, before, after, "data structures should match")
+}

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -1,15 +1,35 @@
 package protocol
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Kind string
+
+const (
+	KindTask    Kind = "task"
+	KindMessage Kind = "message"
+)
+
+type PartKind string
+
+const (
+	PartKindText PartKind = "text"
+	PartKindFile PartKind = "file"
+	PartKindData PartKind = "data"
+)
+
 type Message struct {
-	Role             string           `json:"role"`                       // "user" or "agent"
-	Parts            []map[string]any `json:"parts"`                      // Required message content
-	Metadata         map[string]any   `json:"metadata,omitempty"`         // Optional extension metadata
-	Extensions       []string         `json:"extensions,omitempty"`       // Optional list of extension URIs
-	ReferenceTaskIDs []string         `json:"referenceTaskIds,omitempty"` // Optional task references
-	MessageID        string           `json:"messageId"`                  // Required message ID
-	TaskID           *string          `json:"taskId,omitempty"`           // Optional task ID
-	ContextID        *string          `json:"contextId,omitempty"`        // Optional context ID
-	Kind             string           `json:"kind"`                       // Must be "message"
+	Role             string         `json:"role"`                       // "user" or "agent"
+	Parts            Parts          `json:"parts"`                      // Required message content
+	Metadata         map[string]any `json:"metadata,omitempty"`         // Optional extension metadata
+	Extensions       []string       `json:"extensions,omitempty"`       // Optional list of extension URIs
+	ReferenceTaskIDs []string       `json:"referenceTaskIds,omitempty"` // Optional task references
+	MessageID        string         `json:"messageId"`                  // Required message ID
+	TaskID           *string        `json:"taskId,omitempty"`           // Optional task ID
+	ContextID        *string        `json:"contextId,omitempty"`        // Optional context ID
+	Kind             Kind           `json:"kind"`                       // Must be "message"
 }
 
 type MessageSendParams struct {
@@ -35,4 +55,145 @@ type PushNotificationConfig struct {
 type PushNotificationAuthenticationInfo struct {
 	Schemes     []string `json:"schemes"`               // Required
 	Credentials *string  `json:"credentials,omitempty"` // Optional
+}
+
+type Parts []Part
+
+func (p *Parts) UnmarshalJSON(data []byte) error {
+	var rawParts []json.RawMessage
+	if err := json.Unmarshal(data, &rawParts); err != nil {
+		return err
+	}
+	for _, raw := range rawParts {
+		var kindHolder struct {
+			Kind PartKind `json:"kind"`
+		}
+		if err := json.Unmarshal(raw, &kindHolder); err != nil {
+			return err
+		}
+
+		var part Part
+		switch kindHolder.Kind {
+		case PartKindText:
+			var tp TextPart
+			if err := json.Unmarshal(raw, &tp); err != nil {
+				return err
+			}
+			part = &tp
+		case PartKindFile:
+			var fp FilePart
+			if err := json.Unmarshal(raw, &fp); err != nil {
+				return err
+			}
+			part = &fp
+		case PartKindData:
+			var dp DataPart
+			if err := json.Unmarshal(raw, &dp); err != nil {
+				return err
+			}
+			part = &dp
+		default:
+			return fmt.Errorf("unknown part kind: %s", kindHolder.Kind)
+		}
+
+		*p = append(*p, part)
+	}
+	return nil
+}
+
+type Part interface {
+	PartKind() PartKind
+}
+
+type PartBase struct {
+}
+
+type TextPart struct {
+	PartBase
+	Kind PartKind `json:"kind"` // Must be "text"
+	Text string   `json:"text"` // Required text content
+}
+
+func (p *TextPart) PartKind() PartKind {
+	return p.Kind
+}
+
+type FilePart struct {
+	PartBase
+	Kind PartKind `json:"kind"` // Must be "file"
+	File any      `json:"file"` // Can be FileWithBytes or FileWithUri
+}
+
+func (p *FilePart) PartKind() PartKind {
+	return p.Kind
+}
+
+type DataPart struct {
+	PartBase
+	Kind PartKind       `json:"kind"` // Must be "data"
+	Data map[string]any `json:"data"` // Required structured content
+}
+
+func (p *DataPart) PartKind() PartKind {
+	return p.Kind
+}
+
+type FileBase struct {
+}
+
+type FileWithBytes struct {
+	FileBase
+	Bytes string `json:"bytes"` // Required: base64-encoded content
+}
+
+type FileWithURI struct {
+	FileBase
+	URI string `json:"uri"` // Required: URI to the file
+}
+
+func (m Message) MarshalJSON() ([]byte, error) {
+	type Alias Message
+	m.Kind = "message"
+	return json.Marshal((Alias)(m))
+}
+
+func (p *FilePart) UnmarshalJSON(data []byte) error {
+	// Define an alias to avoid recursion and parse the base part
+	type Alias FilePart
+	aux := &struct {
+		File json.RawMessage `json:"file"`
+		*Alias
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Probe the file kind
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(aux.File, &probe); err != nil {
+		return err
+	}
+
+	// Detect and decode the actual file content
+	switch {
+	case probe["bytes"] != nil:
+		var fwb FileWithBytes
+		if err := json.Unmarshal(aux.File, &fwb); err != nil {
+			return err
+		}
+		p.File = fwb
+	case probe["uri"] != nil:
+		var fwu FileWithURI
+		if err := json.Unmarshal(aux.File, &fwu); err != nil {
+			return err
+		}
+		p.File = fwu
+	default:
+		return fmt.Errorf("unknown file format in FilePart")
+	}
+
+	return nil
 }

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -1,0 +1,26 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilePart_UnmarshalJSON(t *testing.T) {
+	before := FilePart{
+		Kind: PartKindFile,
+		File: FileWithBytes{
+			Bytes: "c29tZSB0ZXh0IGZpbGUgY29udGVudA==", // base64 for "some text file content"
+		},
+	}
+	var after FilePart
+	data, err := json.Marshal(before)
+	require.NoError(t, err, "Failed to marshal FilePart")
+
+	err = after.UnmarshalJSON(data)
+
+	require.NoError(t, err, "Failed to unmarshal FilePart")
+	assert.Equal(t, before, after, "data structures should match")
+}

--- a/internal/protocol/server.go
+++ b/internal/protocol/server.go
@@ -2,6 +2,7 @@ package protocol
 
 type Server interface {
 	Start(ready chan<- struct{}) error
+	SetHandler(handler MessageHandler)
 	Close() error
 }
 

--- a/internal/protocol/task.go
+++ b/internal/protocol/task.go
@@ -1,0 +1,64 @@
+package protocol
+
+type TaskState string
+
+const (
+	// Task received by the server and acknowledged, but processing has not yet actively started.
+	TaskStateSubmitted TaskState = "submitted"
+
+	// Task is actively being processed by the agent.
+	// Client may expect further updates or a terminal state.
+	TaskStateWorking TaskState = "working"
+
+	// Agent requires additional input from the client/user to proceed.
+	// The task is effectively paused.
+	TaskStateInputRequired TaskState = "input-required"
+
+	// Task finished successfully.
+	// Results are typically available in Task.artifacts or TaskStatus.message.
+	TaskStateCompleted TaskState = "completed"
+
+	// Task was canceled (e.g., by a tasks/cancel request or server-side policy).
+	TaskStateCanceled TaskState = "canceled"
+
+	// Task terminated due to an error during processing.
+	// TaskStatus.message may contain error details.
+	TaskStateFailed TaskState = "failed"
+
+	// Task terminated due to rejection by remote agent.
+	// TaskStatus.message may contain error details.
+	TaskStateRejected TaskState = "rejected"
+
+	// Agent requires additional authentication from the client/user to proceed.
+	// The task is effectively paused.
+	TaskStateAuthRequired TaskState = "auth-required"
+
+	// TaskStateUnknown:
+	// The state of the task cannot be determined (e.g., task ID is invalid, unknown, or has expired).
+	TaskStateUnknown TaskState = "unknown"
+)
+
+type Task struct {
+	ID        string         `json:"id"`                  // Required: task ID
+	ContextID string         `json:"contextId"`           // Required: contextual alignment
+	Status    TaskStatus     `json:"status"`              // Required: current status
+	History   []Message      `json:"history,omitempty"`   // Optional: message history
+	Artifacts []Artifact     `json:"artifacts,omitempty"` // Optional: artifacts created
+	Metadata  map[string]any `json:"metadata,omitempty"`  // Optional: extension metadata
+	Kind      Kind           `json:"kind"`                // Required: must be "task"
+}
+
+type TaskStatus struct {
+	State     TaskState `json:"state"`               // Required
+	Message   *Message  `json:"message,omitempty"`   // Optional: additional status message
+	Timestamp *string   `json:"timestamp,omitempty"` // Optional: ISO 8601 datetime string
+}
+
+type Artifact struct {
+	ArtifactID  string           `json:"artifactId"`            // Required: unique identifier
+	Name        *string          `json:"name,omitempty"`        // Optional: human-readable name
+	Description *string          `json:"description,omitempty"` // Optional: human-readable description
+	Parts       []map[string]any `json:"parts"`                 // Required: parts (can be refined later)
+	Metadata    map[string]any   `json:"metadata,omitempty"`    // Optional: extension metadata
+	Extensions  []string         `json:"extensions,omitempty"`  // Optional: contributed extension URIs
+}

--- a/internal/protocol/trpc-server.go
+++ b/internal/protocol/trpc-server.go
@@ -28,6 +28,10 @@ func NewTrpcServer(card AgentCard, port int) (Server, error) {
 	return &TrpcServer{card: card, server: *serv, port: port}, nil
 }
 
+func (s *TrpcServer) SetHandler(handler MessageHandler) {
+	panic("unimplemented")
+}
+
 func (s *TrpcServer) Start(ready chan<- struct{}) error {
 	port := fmt.Sprintf(":%d\n", s.port)
 	if ready != nil {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/cqfn/refrax/cmd"
@@ -11,12 +12,13 @@ import (
 )
 
 func TestEndToEnd_Agents_FromCLI(t *testing.T) {
-	output := &bytes.Buffer{}
+	capture := &bytes.Buffer{}
+	output := io.MultiWriter(capture, os.Stdout)
 	cmd := cmd.NewRootCmd(output, io.Discard)
 	cmd.SetArgs([]string{"refactor", "--ai=none"})
 
 	err := cmd.Execute()
 
 	require.NoError(t, err, "Expected command to execute without error")
-	assert.Contains(t, output.String(), "provider: none", "expect no AI provider to be used in output")
+	assert.Contains(t, capture.String(), "provider: none", "expect no AI provider to be used in output")
 }


### PR DESCRIPTION
Adds integration tests for agent interactions and implements a mock project system for testing refactoring scenarios. The changes enable end-to-end testing of the refactoring workflow with `facilitator` agent and a2a `client`

Related to #8