### PR TITLE
build(#19): fix GitHub owner in goreleaser config for initial release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,6 @@ archives:
 release:
   header: "{{ .TagContents }}"
   github:
-    owner: cfqn 
+    owner: cqfn 
     name: refrax
 


### PR DESCRIPTION
Updates `.goreleaser.yml` with correct GitHub owner name for `refrax` release.

Related to #19