### PR TITLE
feat(#27): add validation for empty projects in refactoring

### DIFF
--- a/;
+++ b/;
@@ -19,7 +19,7 @@ func TestRefraxClient_Refactors_EmptyProject(t *testing.T) {
 
 	assert.Equal(t, origin, proj, "Refactoring an empty project should return the same project")
 	assert.Error(t, err, "Expected an error when refactoring an empty project")
-	assert.Equal(t, "no java classes found in the project [empty project], add java files to the appropriate directory", err.Error(), "Error message should indicate no classes found")
+	assert.Equal(t, "no java classes found in the project [.], add java files to the appropriate directory", err.Error(), "Error message should indicate no classes found")
 }
 
 // func TestRefraxClient_Refactors_Successfully(t *testing.T) {

--- a/internal/client/filesystem_project.go
+++ b/internal/client/filesystem_project.go
@@ -40,6 +40,10 @@ func (p *FilesystemProject) Classes() ([]JavaClass, error) {
 	return classes, nil
 }
 
+func (p *FilesystemProject) String() string {
+	return fmt.Sprintf("[%s]", p.path)
+}
+
 type FilesystemJavaClass struct {
 	name    string
 	content string

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -1,5 +1,10 @@
 package client
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Project interface {
 	Classes() ([]JavaClass, error)
 }
@@ -65,4 +70,15 @@ func (i *InMemoryJavaClass) Content() string {
 
 func (i *InMemoryJavaClass) Name() string {
 	return i.name
+}
+
+func (i *InMemoryProject) String() string {
+	var names []string
+	for name := range i.files {
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return "[empty project]"
+	}
+	return fmt.Sprintf("[%s]", strings.Join(names, ", "))
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1,5 +1,29 @@
 package test
 
+import (
+	"io"
+	"testing"
+
+	"github.com/cqfn/refrax/cmd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndToEnd_Agents_FromCLI_WithoutAI_WithEmptyProject(t *testing.T) {
+	cmd := cmd.NewRootCmd(io.Discard, io.Discard)
+	cmd.SetArgs([]string{"refactor", "--ai=none"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err, "expected command to fail with an empty project")
+	assert.Contains(
+		t,
+		err.Error(),
+		"no java classes found in the project [.], add java files to the appropriate directory",
+		"Expected the output to indicate no AI provider was used and no classes were found",
+	)
+}
+
 // func TestEndToEnd_Agents_FromCLI_WithoutAI_WithMockProject(t *testing.T) {
 // 	capture := &bytes.Buffer{}
 // 	output := io.MultiWriter(capture, os.Stdout)


### PR DESCRIPTION
Improves error handling and messaging when refactoring empty projects without Java files. Adds clear validation and logging for missing classes.

Related to #27