### PR TITLE
ci(#43): add gofmt enforcement via GitHub Action

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,51 @@
+version: "2"
+linters:
+  enable:
+    - dupl
+    - gochecknoinits
+    - gocritic
+    - gocyclo
+    # @todo #43:60min Enable 'gosec' linter
+    #  We need to fix all the security issues and enable this check
+    #  Youu can enable it using '-gosec' entry right below
+    # - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - prealloc
+    # @todo #43:60min Enable 'revive' linter
+    #  We need to fix all the issues identified by 'revive' linter
+    #  and then enable it using the following entry below
+    # - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - goconst
+  settings:
+     goconst:
+       min-len: 2
+       min-occurrences: 2
+     gocritic:
+       disabled-checks:
+         - wrapperFunc
+         - hugeParam
+         - rangeValCopy
+         - singleCaseSwitch
+         - ifElseChain
+       enabled-tags:
+        - performance
+        - style
+        - experimental
+     govet:
+       enable:
+         - shadow
+     lll:
+       line-length: 140
+     misspell:
+       locale: US
+formatters:
+  enable:
+    - gci
+    - gofumpt

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,12 +21,13 @@ func Execute() error {
 	return NewRootCmd(os.Stdout, os.Stderr).Execute()
 }
 
-// @todo #2:45min Add new parameter `--tools` for constructing needed tool for the critic.
+// Command line interface for Refrax.
 //
-//	Currently, we create Aibolit, but it would be great to have such option. Examples of such tools
-//	are: `aibolit`, `none`, etc. We should be able to pass multiple tools, for instance:
-//	`--tools=aibolit,qulice`.
-func NewRootCmd(out io.Writer, err io.Writer) *cobra.Command {
+// @todo #2:45min Add new parameter `--tools` for constructing needed tool for the critic.
+// Currently, we create Aibolit, but it would be great to have such option. Examples of such tools
+// are: `aibolit`, `none`, etc. We should be able to pass multiple tools, for instance:
+// `--tools=aibolit,qulice`.
+func NewRootCmd(out, err io.Writer) *cobra.Command {
 	var params Params
 	root := &cobra.Command{
 		Use:   "refrax",
@@ -46,7 +47,7 @@ func NewRootCmd(out io.Writer, err io.Writer) *cobra.Command {
 	root.PersistentFlags().BoolVar(&params.stats, "stats", false, "Print internal interaction statistics")
 	root.AddCommand(
 		newRefactorCmd(&params),
-		newStartCmd(&params),
+		newStartCmd(),
 	)
 	return root
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,15 +4,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newStartCmd(params *Params) *cobra.Command {
+func newStartCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:     "start [agent]",
 		Short:   "Starts a particular agent like fixer, critic, or facilitator",
 		Args:    cobra.MaximumNArgs(1),
 		Aliases: []string{"st"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// return facilitator.StartServer(params.provider, params.token, 8080)
-			return nil
+			panic("start command is not implemented yet")
 		},
 	}
 	return command

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -4,9 +4,11 @@ type Brain interface {
 	Ask(question string) (string, error)
 }
 
+const deepseek = "deepseek"
+
 func New(provider, token string, playbook ...string) Brain {
 	switch provider {
-	case "deepseek":
+	case deepseek:
 		return NewDeepSeek(token)
 	default:
 		if len(playbook) == 0 {

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 func TestNew_WithDeepSeekProvider_ReturnsDeepSeekBrain(t *testing.T) {
-	provider := "deepseek"
 	token := "valid_token"
 
-	result := New(provider, token)
+	result := New(deepseek, token)
 
 	_, ok := result.(*DeepSeek)
 	require.True(t, ok, "Expected result to be of type DeepSeek")

--- a/internal/brain/deepseek.go
+++ b/internal/brain/deepseek.go
@@ -50,13 +50,13 @@ func (d *DeepSeek) Ask(question string) (string, error) {
 	return d.send("You are a helpful assistant.", question)
 }
 
-func (d *DeepSeek) send(systemPrompt string, userPrompt string) (answer string, err error) {
-	content := trimmed(userPrompt)
-	log.Debug("DeepSeek: sending request with system promt: '%s' and userPrompt: '%s'", systemPrompt, content)
+func (d *DeepSeek) send(system, user string) (answer string, err error) {
+	content := trimmed(user)
+	log.Debug("DeepSeek: sending request with system promt: '%s' and userPrompt: '%s'", system, content)
 	body := deepseekReq{
 		Model: d.model,
 		Messages: []deepseekMsg{
-			{Role: "system", Content: systemPrompt},
+			{Role: "system", Content: system},
 			{Role: "user", Content: content},
 		},
 		Stream: false,
@@ -76,7 +76,7 @@ func (d *DeepSeek) send(systemPrompt string, userPrompt string) (answer string, 
 		return "", fmt.Errorf("error making request to deepseek api: %w", err)
 	}
 	defer func() {
-		if cerr := resp.Body.Close(); err != nil {
+		if cerr := resp.Body.Close(); cerr != nil {
 			err = fmt.Errorf("error closing response body: %w", cerr)
 		}
 	}()
@@ -85,7 +85,7 @@ func (d *DeepSeek) send(systemPrompt string, userPrompt string) (answer string, 
 		return "", fmt.Errorf("API error: %s", content)
 	}
 	var parsed deepseekResp
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return "", fmt.Errorf("error decoding response: %w", err)
 	}
 	if len(parsed.Choices) == 0 {

--- a/internal/brain/deepseek_test.go
+++ b/internal/brain/deepseek_test.go
@@ -46,7 +46,7 @@ func echoServer(t *testing.T) *httptest.Server {
 		w.WriteHeader(http.StatusOK)
 		message := strings.ReplaceAll(request.Messages[1].Content, "\n", "\\n")
 		message = strings.ReplaceAll(message, "\"", "'")
-		resp := fmt.Sprintf(`{"choices":[{"message":{"content":"%s"}}]}`, message)
+		resp := fmt.Sprintf(`{"choices":[{"message":{"content":%q}}]}`, message)
 		_, err = w.Write([]byte(resp))
 		require.NoError(t, err, "Failed to write response")
 	}))

--- a/internal/brain/metric_brain.go
+++ b/internal/brain/metric_brain.go
@@ -12,8 +12,8 @@ type MetricBrain struct {
 	log    log.Logger
 }
 
-func NewMetricBrain(brain Brain, log log.Logger) Brain {
-	return &MetricBrain{brain, []time.Duration{}, log}
+func NewMetricBrain(brain Brain, logger log.Logger) Brain {
+	return &MetricBrain{brain, []time.Duration{}, logger}
 }
 
 func (b *MetricBrain) Ask(question string) (string, error) {
@@ -25,11 +25,10 @@ func (b *MetricBrain) Ask(question string) (string, error) {
 }
 
 // @todo #21:35min Move `PrintStats` method to the more properly organized abstraction.
-//
-//	Currently, we needed it in order to aggregate all the messages in the `stats` map, and then
-//	print it. Since there is no `PrintStats` method in original `Brain`, it looks ugly when we call this
-//	function on `Brain` instance in `refrax_client.go`. We should organize more proper abstraction
-//	around the aggregation and printing of stats.
+// Currently, we needed it in order to aggregate all the messages in the `stats` map, and then
+// print it. Since there is no `PrintStats` method in original `Brain`, it looks ugly when we call this
+// function on `Brain` instance in `refrax_client.go`. We should organize more proper abstraction
+// around the aggregation and printing of stats.
 func (b *MetricBrain) PrintStats() {
 	b.log.Info("Total messages asked: %d", len(b.stats))
 	for i, d := range b.stats {

--- a/internal/brain/mock.go
+++ b/internal/brain/mock.go
@@ -24,15 +24,15 @@ func (b *MockBrain) Ask(question string) (string, error) {
 }
 
 func (b *MockBrain) Playbook() (Playbook, error) {
-	if len(b.playbooks) == 0 {
+	switch len(b.playbooks) {
+	case 0:
 		return &echoPlaybook{}, nil
-	} else if len(b.playbooks) == 1 {
+	case 1:
 		if b.playbooks[0] != "" {
 			return NewYAMLPlaybook(b.playbooks[0])
-		} else {
-			return &echoPlaybook{}, nil
 		}
-	} else {
+		return &echoPlaybook{}, nil
+	default:
 		return nil, fmt.Errorf("mock brain supports only one playbook at a time")
 	}
 }

--- a/internal/brain/yaml_playbook_test.go
+++ b/internal/brain/yaml_playbook_test.go
@@ -31,7 +31,7 @@ qa:
 func TestNewYAMLPlaybook_Success(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "playbook_example.yml")
-	err := os.WriteFile(filePath, []byte(content), 0644)
+	err := os.WriteFile(filePath, []byte(content), 0o644)
 	require.NoError(t, err)
 
 	pb, err := NewYAMLPlaybook(filePath)
@@ -62,7 +62,7 @@ func TestNewYAMLPlaybook_InvalidYAML(t *testing.T) {
 		"  - question: \"What should I rename the variable 'tmp' to?\"",
 		"    answer: [\"This should fail because it's not a string\"]",
 	}, "\n")
-	err := os.WriteFile(filePath, []byte(content), 0644)
+	err := os.WriteFile(filePath, []byte(content), 0o644)
 	require.NoError(t, err)
 
 	pb, err := NewYAMLPlaybook(filePath)
@@ -79,7 +79,7 @@ func TestYAMLPlaybook_Ask_QuestionNotFound(t *testing.T) {
 		"      What should I rename the variable `tmp` to?\n" +
 		"    answer: |\n" +
 		"      You can rename `tmp` to `userID` for better clarity.\n"
-	err := os.WriteFile(path, []byte(content), 0644)
+	err := os.WriteFile(path, []byte(content), 0o644)
 	require.NoError(t, err)
 
 	pb, err := NewYAMLPlaybook(path)

--- a/internal/client/filesystem_project.go
+++ b/internal/client/filesystem_project.go
@@ -60,7 +60,7 @@ func (c *FilesystemJavaClass) Content() string {
 
 func (c *FilesystemJavaClass) SetContent(content string) error {
 	c.content = content
-	err := os.WriteFile(c.path, []byte(content), 0644)
+	err := os.WriteFile(c.path, []byte(content), 0o644)
 	if err != nil {
 		return fmt.Errorf("error writing content to file %s: %w", c.path, err)
 	}

--- a/internal/client/filesystem_project_test.go
+++ b/internal/client/filesystem_project_test.go
@@ -22,8 +22,8 @@ func TestFilesystemProject_Classes_Success(t *testing.T) {
 	tempDir := t.TempDir()
 	first := filepath.Join(tempDir, "Class1.java")
 	second := filepath.Join(tempDir, "Class2.java")
-	require.NoError(t, os.WriteFile(first, []byte("class Class1 {}"), 0644))
-	require.NoError(t, os.WriteFile(second, []byte("class Class2 {}"), 0644))
+	require.NoError(t, os.WriteFile(first, []byte("class Class1 {}"), 0o644))
+	require.NoError(t, os.WriteFile(second, []byte("class Class2 {}"), 0o644))
 	project := NewFilesystemProject(tempDir)
 
 	classes, err := project.Classes()
@@ -49,7 +49,7 @@ func TestFilesystemProject_Classes_EmptyDirectory(t *testing.T) {
 func TestFilesystemProject_Classes_NonJavaFilesIgnored(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "NotAJavaFile.txt")
-	require.NoError(t, os.WriteFile(filePath, []byte("Some content"), 0644))
+	require.NoError(t, os.WriteFile(filePath, []byte("Some content"), 0o644))
 
 	project := NewFilesystemProject(tempDir)
 
@@ -63,8 +63,8 @@ func TestFilesystemProject_Classes_ErrorReadingFile(t *testing.T) {
 	SkipOnWindows(t)
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "Class1.java")
-	require.NoError(t, os.WriteFile(filePath, []byte("class Class1 {}"), 0644))
-	require.NoError(t, os.Chmod(filePath, 0222)) // Write-only
+	require.NoError(t, os.WriteFile(filePath, []byte("class Class1 {}"), 0o644))
+	require.NoError(t, os.Chmod(filePath, 0o222)) // Write-only
 
 	project := NewFilesystemProject(tempDir)
 
@@ -78,14 +78,14 @@ func TestFilesystemProject_Classes_ErrorDuringTraversal(t *testing.T) {
 	SkipOnWindows(t)
 	tempDir := t.TempDir()
 	subDir := filepath.Join(tempDir, "subdir")
-	require.NoError(t, os.Mkdir(subDir, 0000)) // No permissions
+	require.NoError(t, os.Mkdir(subDir, 0o000)) // No permissions
 	project := NewFilesystemProject(tempDir)
 
 	classes, err := project.Classes()
 
 	assert.Nil(t, classes)
 	assert.Error(t, err)
-	require.NoError(t, os.Chmod(subDir, 0755))
+	require.NoError(t, os.Chmod(subDir, 0o755))
 }
 
 func TestFilesystemJavaClass_Name(t *testing.T) {
@@ -103,7 +103,7 @@ func TestFilesystemJavaClass_Content(t *testing.T) {
 func TestFilesystemJavaClass_SetContent_Success(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "TestClass.java")
-	require.NoError(t, os.WriteFile(filePath, []byte("class TestClass {}"), 0644))
+	require.NoError(t, os.WriteFile(filePath, []byte("class TestClass {}"), 0o644))
 	class := &FilesystemJavaClass{
 		name:    "TestClass",
 		content: "class TestClass {}",

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -73,7 +73,7 @@ func (i *InMemoryJavaClass) Name() string {
 }
 
 func (i *InMemoryProject) String() string {
-	var names []string
+	names := make([]string, 0, len(i.files))
 	for name := range i.files {
 		names = append(names, name)
 	}

--- a/internal/critic/server.go
+++ b/internal/critic/server.go
@@ -107,7 +107,7 @@ func (c *Critic) think(m *protocol.Message) (*protocol.Message, error) {
 	}
 	res := builder.Build()
 	c.log.Debug("sending response: %s", res)
-	return &res, nil
+	return res, nil
 }
 
 func parseAnswer(answer string) []string {
@@ -122,7 +122,7 @@ func parseAnswer(answer string) []string {
 	return suggestions
 }
 
-func agentCard(port int) protocol.AgentCard {
+func agentCard(port int) *protocol.AgentCard {
 	return protocol.Card().
 		Name("Critic Agent").
 		Description("Critic Description").

--- a/internal/critic/server_test.go
+++ b/internal/critic/server_test.go
@@ -43,18 +43,18 @@ func (m *MockServer) SetHandler(handler protocol.MessageHandler) {
 type MockBrain struct{}
 
 func TestNewCritic_Success(t *testing.T) {
-	brain := brain.NewMock()
+	ai := brain.NewMock()
 
-	critic := NewCritic(brain, 18081)
+	critic := NewCritic(ai, 18081)
 	require.NotNil(t, critic)
-	assert.Equal(t, brain, critic.brain)
+	assert.Equal(t, ai, critic.brain)
 }
 
 func TestCriticStart_Success(t *testing.T) {
-	brain := brain.NewMock()
+	ai := brain.NewMock()
 	port, err := protocol.FreePort()
 	require.NoError(t, err)
-	critic := NewCritic(brain, port)
+	critic := NewCritic(ai, port)
 	ready := make(chan struct{})
 
 	go func() { err = critic.Start(ready) }()
@@ -66,8 +66,8 @@ func TestCriticStart_Success(t *testing.T) {
 }
 
 func TestCriticStart_ServerStartError(t *testing.T) {
-	brain := brain.NewMock()
-	critic := NewCritic(brain, 18081)
+	ai := brain.NewMock()
+	critic := NewCritic(ai, 18081)
 	critic.server = &MockServer{started: true}
 	ready := make(chan struct{})
 
@@ -78,9 +78,9 @@ func TestCriticStart_ServerStartError(t *testing.T) {
 }
 
 func TestCriticClose_Success(t *testing.T) {
-	brain := brain.NewMock()
+	ai := brain.NewMock()
 	server := &MockServer{started: true}
-	critic := NewCritic(brain, 18081)
+	critic := NewCritic(ai, 18081)
 	critic.server = server
 
 	err := critic.Close()
@@ -90,9 +90,9 @@ func TestCriticClose_Success(t *testing.T) {
 }
 
 func TestCriticClose_ServerNotStartedError(t *testing.T) {
-	brain := brain.NewMock()
+	ai := brain.NewMock()
 	server := &MockServer{}
-	critic := NewCritic(brain, 18081, NewMockToolEmpty())
+	critic := NewCritic(ai, 18081, NewMockToolEmpty())
 	critic.server = server
 
 	err := critic.Close()
@@ -102,15 +102,15 @@ func TestCriticClose_ServerNotStartedError(t *testing.T) {
 }
 
 func TestCriticThink_ReturnsMessage(t *testing.T) {
-	brain := brain.NewMock()
+	ai := brain.NewMock()
 	server := &MockServer{}
-	critic := NewCritic(brain, 18081, NewMockToolEmpty())
+	critic := NewCritic(ai, 18081, NewMockToolEmpty())
 	critic.server = server
 	msg := protocol.NewMessageBuilder().
 		MessageID("msg-123").
 		Build()
 
-	response, err := critic.think(&msg)
+	response, err := critic.think(msg)
 
 	require.NoError(t, err)
 	assert.Equal(t, msg.MessageID, response.MessageID)

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -7,7 +7,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func Token(path string, provider string) string {
+func Token(path, provider string) string {
 	switch provider {
 	case "deepseek":
 		return find(path, "DEEPSEEK_TOKEN")
@@ -18,7 +18,7 @@ func Token(path string, provider string) string {
 	}
 }
 
-func find(path string, variable string) string {
+func find(path, variable string) string {
 	envs, err := godotenv.Read(path)
 	if err != nil {
 		log.Info(".env file not found at %s, using default environment settings and parameters", path)

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -14,7 +14,7 @@ func TestToken_LoadsTokenFromEnvFile(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, ".env")
 	content := "TOKEN=test-token"
-	err := os.WriteFile(file, []byte(content), 0644)
+	err := os.WriteFile(file, []byte(content), 0o644)
 	require.NoError(t, err)
 
 	token := Token(file, "otherprovider")
@@ -32,7 +32,7 @@ func TestToken_EnvVariableNotSetReturnsEmptyString(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, ".env")
 	content := "OTHER_VAR=other-value"
-	err := os.WriteFile(file, []byte(content), 0644)
+	err := os.WriteFile(file, []byte(content), 0o644)
 	require.NoError(t, err)
 
 	token := Token(file, "otherprovider")
@@ -44,7 +44,7 @@ func TestToken_HandlesInvalidEnvFileGracefully(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, ".env")
 	content := "\x00TOKEN=test-token"
-	err := os.WriteFile(file, []byte(content), 0644)
+	err := os.WriteFile(file, []byte(content), 0o644)
 	require.NoError(t, err)
 
 	token := Token(file, "unknown")
@@ -55,7 +55,7 @@ func TestToken_HandlesInvalidEnvFileGracefully(t *testing.T) {
 func TestToken_EmptyEnvFileUsesDefaultEnv(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, ".env")
-	err := os.WriteFile(file, []byte(""), 0644)
+	err := os.WriteFile(file, []byte(""), 0o644)
 	require.NoError(t, err)
 
 	token := Token(file, "unknown")
@@ -67,7 +67,7 @@ func TestProviderToken_DeepseekTokenPresent(t *testing.T) {
 	tmp := t.TempDir()
 	deepseek := "deepseek-token-value"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s", deepseek), 0644)
+	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s", deepseek), 0o644)
 	require.NoError(t, err)
 
 	result := Token(env, "deepseek")
@@ -79,7 +79,7 @@ func TestProviderToken_DefaultTokenPresent(t *testing.T) {
 	tmp := t.TempDir()
 	token := "default-token-value"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "TOKEN=%s", token), 0644)
+	err := os.WriteFile(env, fmt.Appendf(nil, "TOKEN=%s", token), 0o644)
 	require.NoError(t, err)
 
 	result := Token(env, "otherprovider")
@@ -102,10 +102,10 @@ func TestProviderToken_DefaultTokenAbsent(t *testing.T) {
 
 func TestProviderToken_DeepseekTokenIgnoredWhenDefaultTokenExists(t *testing.T) {
 	tmp := t.TempDir()
-	deepseek := "deepseek-token-value"
-	token := "default-token-value"
+	deepseek := "deepseek-token-val"
+	token := "default-token-val"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s\nTOKEN=%s\n", deepseek, token), 0644)
+	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s\nTOKEN=%s\n", deepseek, token), 0o644)
 	require.NoError(t, err)
 
 	result := Token(env, "deepseek")
@@ -115,10 +115,10 @@ func TestProviderToken_DeepseekTokenIgnoredWhenDefaultTokenExists(t *testing.T) 
 
 func TestProviderToken_DefaultTokenUsedWhenDeepseekNotRequested(t *testing.T) {
 	tmp := t.TempDir()
-	deepseek := "deepseek-token-value"
-	token := "default-token-value"
+	deepseek := "deepseek-token"
+	token := "default-token"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s\nTOKEN=%s\n", deepseek, token), 0644)
+	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s\nTOKEN=%s\n", deepseek, token), 0o644)
 	require.NoError(t, err)
 
 	result := Token(env, "otherprovider")

--- a/internal/facilitator/server.go
+++ b/internal/facilitator/server.go
@@ -18,7 +18,7 @@ type Facilitator struct {
 	fixerPort  int
 }
 
-func NewFacilitator(ai brain.Brain, port int, criticPort int, fixerPort int) *Facilitator {
+func NewFacilitator(ai brain.Brain, port, criticPort, fixerPort int) *Facilitator {
 	logger := log.NewPrefixed("facilitator", log.Default())
 	logger.Debug("preparing server on port %d with ai provider %s", port, ai)
 	server := protocol.NewCustomServer(agentCard(port), port)
@@ -97,7 +97,7 @@ func (f *Facilitator) think(m *protocol.Message) (*protocol.Message, error) {
 		Part(filePartResult).
 		Build()
 	f.log.Debug("sending response: %s", res)
-	return &res, nil
+	return res, nil
 }
 
 func (f *Facilitator) AskFixer(id string, suggestions []string, file *protocol.FilePart) (*protocol.JSONRPCResponse, error) {
@@ -131,7 +131,7 @@ func (f *Facilitator) AskCritic(id string, file *protocol.FilePart) (*protocol.J
 	)
 }
 
-func agentCard(port int) protocol.AgentCard {
+func agentCard(port int) *protocol.AgentCard {
 	return protocol.Card().
 		Name("Facilitator Agent").
 		Description("An agent that facilitates talk between critic and fixer").

--- a/internal/fixer/server.go
+++ b/internal/fixer/server.go
@@ -94,7 +94,7 @@ func (c *Fixer) think(m *protocol.Message) (*protocol.Message, error) {
 		MessageID(m.MessageID).
 		Part(protocol.NewFileBytes([]byte(clean(answer)))).
 		Build()
-	return &message, nil
+	return message, nil
 }
 
 func clean(answer string) string {
@@ -102,7 +102,7 @@ func clean(answer string) string {
 	return strings.ReplaceAll(answer, "```", "")
 }
 
-func agentCard(port int) protocol.AgentCard {
+func agentCard(port int) *protocol.AgentCard {
 	return protocol.Card().
 		Name("Fixer Agent").
 		Description("Fixer Description").

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -32,9 +32,9 @@ func TestSetAndGetLogger(t *testing.T) {
 	mock := &MockLogger{}
 	Set(mock)
 
-	initialised := Default()
+	initialized := Default()
 
-	assert.Equal(t, mock, initialised, "Expected retrieved logger to be the mock logger")
+	assert.Equal(t, mock, initialized, "Expected retrieved logger to be the mock logger")
 }
 
 func TestSetLoggerNilPanics(t *testing.T) {

--- a/internal/log/prefixed_test.go
+++ b/internal/log/prefixed_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewPrefixed(t *testing.T) {
 	mock := NewMock()
-	prefix := "test-prefix"
+	prefix := "prefix"
 	prefixed := NewPrefixed(prefix, mock)
 	require.NotNil(t, prefixed)
 

--- a/internal/protocol/builders.go
+++ b/internal/protocol/builders.go
@@ -60,7 +60,7 @@ func (b *AgentCardBuilder) DefaultOutputModes(modes []string) *AgentCardBuilder 
 }
 
 func (b *AgentCardBuilder) Skill(id, name, description string) *AgentCardBuilder {
-	var skill = AgentSkill{
+	skill := AgentSkill{
 		Name:        name,
 		Description: description,
 	}
@@ -73,6 +73,6 @@ func (b *AgentCardBuilder) Skills(skills []AgentSkill) *AgentCardBuilder {
 	return b
 }
 
-func (b *AgentCardBuilder) Build() AgentCard {
-	return *b.card
+func (b *AgentCardBuilder) Build() *AgentCard {
+	return b.card
 }

--- a/internal/protocol/custom_client.go
+++ b/internal/protocol/custom_client.go
@@ -84,11 +84,11 @@ func (client *CustomClient) doRequest(req any, resp *JSONRPCResponse) error {
 	if err := json.NewDecoder(httpResp.Body).Decode(&rawResp); err != nil {
 		return fmt.Errorf("failed to decode response: %w", err)
 	}
-	copy(&rawResp, resp)
+	copyResp(&rawResp, resp)
 	return nil
 }
 
-func copy(from *JSONRPCResponse, to *JSONRPCResponse) {
+func copyResp(from, to *JSONRPCResponse) {
 	to.JSONRPC = from.JSONRPC
 	to.ID = from.ID
 	to.Result = from.Result

--- a/internal/protocol/custom_client_test.go
+++ b/internal/protocol/custom_client_test.go
@@ -10,7 +10,6 @@ import (
 func TestCustomClient_SendsMessage(t *testing.T) {
 	var err error
 	serv, port, ready := testServer(t)
-	closeResource(serv, &err)
 	<-ready
 	client := NewCustomClient(fmt.Sprintf("http://localhost:%d", port))
 	message := MessageSendParams{
@@ -19,17 +18,15 @@ func TestCustomClient_SendsMessage(t *testing.T) {
 
 	resp, err := client.SendMessage(message)
 
+	require.NoError(t, err, "Failed to send message")
+	err = serv.Close()
+	require.NoError(t, err, "Failed to close server")
 	expected := &JSONRPCResponse{
 		ID:      "1",
 		JSONRPC: "2.0",
-		Result:  tellJoke(),
+		Result:  *tellJoke(),
 	}
 	require.NoError(t, err, "Failed to send message")
 	require.NotNil(t, resp, "Response should not be nil")
 	require.Equal(t, expected, resp, "Response text should match")
-
-	// response, err := client.SendMessage(message)
-	// require.NoError(t, err, "Failed to send message")
-	// assert.NotNil(t, response, "Response should not be nil")
-	// assert.Equal(t, "Hello, world!", response.Result.Parts[0]["text"], "Response text should match")
 }

--- a/internal/protocol/custom_server.go
+++ b/internal/protocol/custom_server.go
@@ -19,11 +19,11 @@ type CustomServer struct {
 	server  *http.Server
 }
 
-func NewCustomServer(card AgentCard, port int) Server {
+func NewCustomServer(card *AgentCard, port int) Server {
 	mux := http.NewServeMux()
 	server := &CustomServer{
 		mux:     mux,
-		card:    card,
+		card:    *card,
 		port:    port,
 		handler: LogRequest,
 		server: &http.Server{
@@ -137,7 +137,7 @@ func toString(v any) string {
 
 func (s *CustomServer) handleMessageSend(w http.ResponseWriter, params *MessageSendParams, id string) error {
 	msg := params.Message
-	udpadted, err := s.handler(&msg)
+	udpadted, err := s.handler(msg)
 	if err != nil {
 		return err
 	}

--- a/internal/protocol/jsonrpc_test.go
+++ b/internal/protocol/jsonrpc_test.go
@@ -11,7 +11,7 @@ import (
 func TestJSONRPCResponse_UnmarshalMessage(t *testing.T) {
 	before := JSONRPCResponse{
 		ID: float64(1),
-		Result: NewMessageBuilder().
+		Result: *NewMessageBuilder().
 			MessageID("363422be-b0f9-4692-a24d-278670e7c7f1").
 			Role("agent").
 			Part(NewText("Why did the chicken cross the road? To get to the other side!")).

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -20,12 +20,12 @@ type Message struct {
 }
 
 type MessageBuilder struct {
-	msg Message
+	msg *Message
 }
 
 func NewMessageBuilder() *MessageBuilder {
 	return &MessageBuilder{
-		msg: Message{
+		msg: &Message{
 			Kind: KindMessage,
 		},
 	}
@@ -74,6 +74,6 @@ func (b *MessageBuilder) ContextID(contextID string) *MessageBuilder {
 	return b
 }
 
-func (b *MessageBuilder) Build() Message {
+func (b *MessageBuilder) Build() *Message {
 	return b.msg
 }

--- a/internal/protocol/message_send.go
+++ b/internal/protocol/message_send.go
@@ -1,7 +1,7 @@
 package protocol
 
 type MessageSendParams struct {
-	Message       Message                   `json:"message"`                 // Required
+	Message       *Message                  `json:"message"`                 // Required
 	Configuration *MessageSendConfiguration `json:"configuration,omitempty"` // Optional
 	Metadata      map[string]any            `json:"metadata,omitempty"`      // Optional key-value extension metadata
 }
@@ -14,7 +14,7 @@ type MessageSendConfiguration struct {
 }
 
 type MessageSendParamsBuilder struct {
-	message       Message
+	message       *Message
 	configuration *MessageSendConfiguration
 	metadata      map[string]any
 }
@@ -23,7 +23,7 @@ func NewMessageSendParamsBuilder() *MessageSendParamsBuilder {
 	return &MessageSendParamsBuilder{}
 }
 
-func (b *MessageSendParamsBuilder) Message(msg Message) *MessageSendParamsBuilder {
+func (b *MessageSendParamsBuilder) Message(msg *Message) *MessageSendParamsBuilder {
 	b.message = msg
 	return b
 }

--- a/internal/protocol/server_test.go
+++ b/internal/protocol/server_test.go
@@ -19,7 +19,7 @@ func TestServer_AgentCard(t *testing.T) {
 	require.NoError(t, err, "expected no error creating server")
 	cserver := server.(*CustomServer)
 	require.NoError(t, err, "expected no error creating server")
-	req, err := http.NewRequest(http.MethodGet, "/.well-known/agent-card.json", nil)
+	req, err := http.NewRequest(http.MethodGet, "/.well-known/agent-card.json", http.NoBody)
 	require.NoError(t, err, "could not create request")
 	rec := httptest.NewRecorder()
 
@@ -29,7 +29,7 @@ func TestServer_AgentCard(t *testing.T) {
 	var card AgentCard
 	err = json.NewDecoder(rec.Body).Decode(&card)
 	require.NoError(t, err, "expected no error decoding response")
-	assert.Equal(t, mockCard(port), card, "Expected agent card to match")
+	assert.Equal(t, *mockCard(port), card, "Expected agent card to match")
 }
 
 func TestServer_AgentCard_MethodNotAllowed(t *testing.T) {
@@ -39,7 +39,7 @@ func TestServer_AgentCard_MethodNotAllowed(t *testing.T) {
 	server.SetHandler(joke)
 	assert.NoError(t, err, "expected no error creating server")
 	cserver := server.(*CustomServer)
-	req, err := http.NewRequest(http.MethodPost, "/.well-known/agent-card.json", nil)
+	req, err := http.NewRequest(http.MethodPost, "/.well-known/agent-card.json", http.NoBody)
 	require.NoError(t, err, "expected no error creating request")
 	rec := httptest.NewRecorder()
 
@@ -48,7 +48,7 @@ func TestServer_AgentCard_MethodNotAllowed(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code, "Expected status Method Not Allowed")
 }
 
-func mockCard(port int) AgentCard {
+func mockCard(port int) *AgentCard {
 	return Card().
 		Name("Test Agent").
 		Description("A test agent for unit tests").

--- a/internal/protocol/trpc_server.go
+++ b/internal/protocol/trpc_server.go
@@ -12,16 +12,16 @@ import (
 type TrpcServer struct {
 	server server.A2AServer
 	port   int
-	card   AgentCard
+	card   *AgentCard
 }
 
-func NewTrpcServer(card AgentCard, port int) (Server, error) {
+func NewTrpcServer(card *AgentCard, port int) (Server, error) {
 	processor := &myTaskProcessor{}
 	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create task manager: %w", err)
 	}
-	serv, err := server.NewA2AServer(agentCard(card), taskManager)
+	serv, err := server.NewA2AServer(*agentCard(card), taskManager)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create A2A server: %w", err)
 	}
@@ -50,8 +50,8 @@ func (s *TrpcServer) Close() error {
 	return nil
 }
 
-func agentCard(card AgentCard) server.AgentCard {
-	return server.AgentCard{
+func agentCard(card *AgentCard) *server.AgentCard {
+	return &server.AgentCard{
 		Name:             card.Name,
 		Description:      &card.Description,
 		URL:              card.URL,
@@ -70,7 +70,8 @@ func agentCard(card AgentCard) server.AgentCard {
 		DefaultOutputModes: card.DefaultOutputModes,
 		Skills: func() []server.AgentSkill {
 			var skills []server.AgentSkill
-			for _, skill := range card.Skills {
+			for i := range card.Skills {
+				skill := &card.Skills[i]
 				skills = append(skills, server.AgentSkill{
 					Name:        skill.Name,
 					Description: &skill.Description,
@@ -92,8 +93,7 @@ func boolean(b *bool) bool {
 	return *b
 }
 
-type myTaskProcessor struct {
-}
+type myTaskProcessor struct{}
 
 func (p *myTaskProcessor) Process(
 	ctx context.Context,

--- a/internal/protocol/trpc_server_test.go
+++ b/internal/protocol/trpc_server_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestTrpcServer_Creates_Successfully(t *testing.T) {
 	port := 16745
-	server, err := NewTrpcServer(mockCard(port), port)
+	card := mockCard(port)
+	server, err := NewTrpcServer(card, port)
 
 	require.NoError(t, err, "should create a new TRPC server without error")
 	assert.NotNil(t, server, "server should not be nil")

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func TestEndToEnd_Agents_FromCLI_WithoutAI_WithEmptyProject(t *testing.T) {
-	cmd := cmd.NewRootCmd(io.Discard, io.Discard)
-	cmd.SetArgs([]string{"refactor", "--ai=none"})
+	command := cmd.NewRootCmd(io.Discard, io.Discard)
+	command.SetArgs([]string{"refactor", "--ai=none"})
 
-	err := cmd.Execute()
+	err := command.Execute()
 
 	require.Error(t, err, "expected command to fail with an empty project")
 	assert.Contains(
@@ -32,10 +32,10 @@ func TestEndToEnd_Agents_FromCLI_WithoutAI_WithEmptyProject(t *testing.T) {
 func TestEndToEnd_Agents_FromCLI_WithoutAI_WithMockProject(t *testing.T) {
 	capture := Buff()
 	output := io.MultiWriter(capture, os.Stdout)
-	cmd := cmd.NewRootCmd(output, io.Discard)
-	cmd.SetArgs([]string{"refactor", "--ai=none", "--mock", "--debug"})
+	command := cmd.NewRootCmd(output, io.Discard)
+	command.SetArgs([]string{"refactor", "--ai=none", "--mock", "--debug"})
 
-	err := cmd.Execute()
+	err := command.Execute()
 
 	require.NoError(t, err, "Expected command to execute without error")
 	assert.Contains(t, capture.String(), "provider: none", "expect no AI provider to be used in output")
@@ -48,11 +48,11 @@ func TestEndToEnd_JavaRefactor_InlineVariable_WithoutAI(t *testing.T) {
 	jclass := setupJava(t, before)
 	capture := Buff()
 	output := io.MultiWriter(capture, os.Stdout)
-	cmd := cmd.NewRootCmd(output, io.Discard)
+	command := cmd.NewRootCmd(output, io.Discard)
 	playbook := filepath.Join("test_data", "refactor.yml")
-	cmd.SetArgs([]string{"refactor", "--ai=none", "--debug", fmt.Sprintf("--playbook=%s", playbook), jclass})
+	command.SetArgs([]string{"refactor", "--ai=none", "--debug", fmt.Sprintf("--playbook=%s", playbook), jclass})
 
-	err := cmd.Execute()
+	err := command.Execute()
 
 	require.NoError(t, err, "Expected command to execute without error")
 	assert.Contains(t, capture.String(), "provider: none", "expect no AI provider to be used in output")
@@ -63,12 +63,12 @@ func setupJava(t *testing.T, code string) string {
 	t.Helper()
 	tmp := t.TempDir()
 	java := filepath.Join(tmp, "Main.java")
-	err := os.WriteFile(java, []byte(code), 0644)
+	err := os.WriteFile(java, []byte(code), 0o644)
 	require.NoError(t, err, "Expected to write mock project file without error")
 	return java
 }
 
-func assertContent(t *testing.T, path string, expected string) {
+func assertContent(t *testing.T, path, expected string) {
 	t.Helper()
 	content, err := os.ReadFile(path)
 	require.NoError(t, err, "Expected to read file content without error")


### PR DESCRIPTION
This PR adds a `.golangci.yml` configuration to enforce code formatting and linting rules, including `gofumpt` for strict `gofmt`-compatible formatting. It also includes various code style improvements to comply with the new linting standards.

Fixes #43