### PR TITLE
feat(#55): add --output flag to refactor command for project mirroring

### DIFF
--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -11,6 +11,7 @@ import (
 )
 
 func newRefactorCmd(params *Params) *cobra.Command {
+	var output string
 	command := &cobra.Command{
 		Use:     "refactor [path]",
 		Short:   "refactor code in the given directory (defaults to current)",
@@ -31,19 +32,28 @@ func newRefactorCmd(params *Params) *cobra.Command {
 				token = env.Token(".env", params.provider)
 			}
 			log.Debug("using provided token: %s...", mask(token))
-			ref, err := client.Refactor(params.provider, token, project(path, params), params.stats, log.Default(), params.playbook)
+			proj, err := project(path, output, params)
+			if err != nil {
+				return err
+			}
+			ref, err := client.Refactor(params.provider, token, proj, params.stats, log.Default(), params.playbook)
 			log.Debug("refactor result: %s", ref)
 			return err
 		},
 	}
+	command.Flags().StringVarP(&output, "output", "o", "", "output path for the refactored code")
 	return command
 }
 
-func project(path string, params *Params) client.Project {
+func project(path, output string, params *Params) (client.Project, error) {
 	if params.mock {
-		return client.NewMockProject()
+		return client.NewMockProject(), nil
 	}
-	return client.NewFilesystemProject(path)
+	input := client.NewFilesystemProject(path)
+	if output != "" {
+		return client.NewMirrorProject(input, output)
+	}
+	return input, nil
 }
 
 func mask(token string) string {

--- a/internal/client/mirror_project.go
+++ b/internal/client/mirror_project.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"fmt"
+	"os"
+)
+
+// MirrorProject decorates FilesystemProject with a mirror location to avoid modifying the original.
+type MirrorProject struct {
+	mirror Project
+}
+
+// NewMirrorProject creates a mirror of the original FilesystemProject at the given path.
+func NewMirrorProject(original *FilesystemProject, mirrorPath string) (*MirrorProject, error) {
+	err := os.CopyFS(mirrorPath, os.DirFS(original.path))
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy project: %w", err)
+	}
+	return &MirrorProject{mirror: NewFilesystemProject(mirrorPath)}, nil
+}
+
+// Classes retrieves all Java classes from the mirrored project.
+func (m *MirrorProject) Classes() ([]JavaClass, error) {
+	return m.mirror.Classes()
+}

--- a/internal/client/mirror_project_test.go
+++ b/internal/client/mirror_project_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMirrorProject_Mirrors_Successfully(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(srcDir, "Copy.java"), []byte("class Copy{}"), 0o600)
+	require.NoError(t, err)
+
+	original := NewFilesystemProject(srcDir)
+
+	mp, err := NewMirrorProject(original, dstDir)
+	require.NoError(t, err)
+	require.NotNil(t, mp)
+
+	_, err = os.Stat(filepath.Join(dstDir, "Copy.java"))
+	assert.NoError(t, err)
+}
+
+func TestNewMirrorProject_CreatesDirectories(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "nonexistent", "dir")
+
+	original := NewFilesystemProject(srcDir)
+	mp, err := NewMirrorProject(original, dstDir)
+
+	require.NoError(t, err)
+	require.NotNil(t, mp)
+	_, err = os.Stat(dstDir)
+	assert.NoError(t, err)
+}
+
+func TestMirrorProject_Classes(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(src, "App.java"), []byte("public class App{}"), 0o600)
+	require.NoError(t, err)
+
+	original := NewFilesystemProject(src)
+	mp, err := NewMirrorProject(original, dst)
+	require.NoError(t, err)
+
+	classes, err := mp.Classes()
+	assert.NoError(t, err)
+	assert.NotNil(t, classes)
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -85,6 +85,23 @@ func TestEndToEnd_JavaRefactor_ManyJavaFilesProject(t *testing.T) {
 	require.NoError(t, err, "Expected command to execute without error")
 }
 
+func TestEndToEnd_OuputOption_CopiesProject(t *testing.T) {
+	tmp := t.TempDir()
+	project := filepath.Join("test_data", "java", "person")
+
+	capture := buff()
+	output := io.MultiWriter(capture, os.Stdout)
+	command := cmd.NewRootCmd(output, io.Discard)
+	command.SetArgs([]string{"refactor", "--ai=none", "--debug", "--output=" + tmp, project})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "Expected command to execute without error")
+	assert.FileExists(t, filepath.Join(tmp, "src", "com", "example", "MainApp.java"), "Expected MainApp.java to be copied to output directory")
+	assert.FileExists(t, filepath.Join(tmp, "src", "com", "example", "model", "Person.java"), "Expected Person.java to be copied to output directory")
+	assert.FileExists(t, filepath.Join(tmp, "src", "com", "example", "service", "GreetingService.java"), "Expected GreetingService.java to be copied to output directory")
+}
+
 func setupJava(t *testing.T, path, name, code string) string {
 	t.Helper()
 	full := filepath.Clean(path)


### PR DESCRIPTION
Adds an `--output` flag to `refactor` command that copies the project to a specified directory instead of modifying the original, enabling safe side-by-side comparison of changes. Includes tests for the new mirror project functionality.

Fixes #55