### PR TITLE
fix(#39): implement stats writer interface for metric brain

### DIFF
--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -36,7 +36,7 @@ func newRefactorCmd(params *Params) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ref, err := client.Refactor(params.provider, token, proj, params.stats, log.Default(), params.playbook)
+			ref, err := client.Refactor(params.provider, token, proj, params.stats, params.format, params.soutput, log.Default(), params.playbook)
 			log.Debug("refactor result: %s", ref)
 			return err
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ type Params struct {
 	mock     bool
 	debug    bool
 	stats    bool
+	format   string
+	soutput  string
 }
 
 // Execute runs the root command and returns any error encountered.
@@ -38,6 +40,8 @@ func NewRootCmd(out, _ io.Writer) *cobra.Command {
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			if params.debug {
 				log.Set(log.NewZerolog(out, "debug"))
+			} else {
+				log.Set(log.NewZerolog(out, "info"))
 			}
 		},
 	}
@@ -47,6 +51,8 @@ func NewRootCmd(out, _ io.Writer) *cobra.Command {
 	root.PersistentFlags().BoolVar(&params.mock, "mock", false, "Use mock project")
 	root.PersistentFlags().BoolVarP(&params.debug, "debug", "d", false, "print debug logs")
 	root.PersistentFlags().BoolVar(&params.stats, "stats", false, "Print internal interaction statistics")
+	root.PersistentFlags().StringVar(&params.format, "stats-format", "std", "Format for statistics output (e.g., std, csv, etc.)")
+	root.PersistentFlags().StringVar(&params.soutput, "stats-output", "stats", "Output path for statistics (default: stats)")
 	root.AddCommand(
 		newRefactorCmd(&params),
 		newStartCmd(),

--- a/internal/brain/csv_writer.go
+++ b/internal/brain/csv_writer.go
@@ -1,0 +1,45 @@
+package brain
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/cqfn/refrax/internal/log"
+)
+
+type csvWriter struct {
+	path string
+}
+
+// NewCSVWriter created an instance of StatsWriter that saves
+// statistics in CSV format.
+func NewCSVWriter(path string) StatsWriter {
+	return &csvWriter{path: path}
+}
+
+func (c *csvWriter) Print(stats *Stats) error {
+	file, err := os.Create(c.path)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	w := csv.NewWriter(file)
+	defer w.Flush()
+	if err = w.Write([]string{"Question", "Duration"}); err != nil {
+		return fmt.Errorf("failed to write header: %v", err)
+	}
+	for i, duration := range stats.Durations() {
+		if err = w.Write([]string{strconv.Itoa(i + 1), duration.String()}); err != nil {
+			return fmt.Errorf("failed to write row %d: %v", i+1, err)
+		}
+	}
+	abs, err := filepath.Abs(c.path)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+	log.Info("statistics written to %s", abs)
+	return nil
+}

--- a/internal/brain/csv_writer_test.go
+++ b/internal/brain/csv_writer_test.go
@@ -1,0 +1,40 @@
+package brain
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCSVWriter(t *testing.T) {
+	require.NotNil(t, NewCSVWriter(filepath.Join(t.TempDir(), "test_path.csv")))
+}
+
+func TestCSVWriter_Print_Success(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "output.csv")
+	w := NewCSVWriter(p)
+	stats := &Stats{}
+	stats.Add(1 * time.Second)
+	stats.Add(2 * time.Second)
+	stats.Add(3 * time.Second)
+
+	err := w.Print(stats)
+
+	require.NoError(t, err)
+	file, err := os.Open(filepath.Clean(p))
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+	lines, err := csv.NewReader(file).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, lines, 4)
+	assert.Equal(t, []string{"Question", "Duration"}, lines[0])
+	assert.Equal(t, []string{"1", "1s"}, lines[1])
+	assert.Equal(t, []string{"2", "2s"}, lines[2])
+	assert.Equal(t, []string{"3", "3s"}, lines[3])
+}

--- a/internal/brain/metric_brain.go
+++ b/internal/brain/metric_brain.go
@@ -2,22 +2,19 @@ package brain
 
 import (
 	"time"
-
-	"github.com/cqfn/refrax/internal/log"
 )
 
 // MetricBrain is a wrapper around a Brain with added functionality
 // to track metrics such as the duration of each question asked.
 type MetricBrain struct {
 	origin Brain
-	stats  []time.Duration
-	log    log.Logger
+	stats  *Stats
 }
 
 // NewMetricBrain creates a new MetricBrain instance wrapping the given Brain
-// and using the provided logger for logging statistics.
-func NewMetricBrain(brain Brain, logger log.Logger) Brain {
-	return &MetricBrain{brain, []time.Duration{}, logger}
+// and using the provided stats for writing statistics.
+func NewMetricBrain(brain Brain, s *Stats) Brain {
+	return &MetricBrain{brain, s}
 }
 
 // Ask sends a question to the underlying Brain and tracks the time
@@ -26,19 +23,6 @@ func (b *MetricBrain) Ask(question string) (string, error) {
 	start := time.Now()
 	result, err := b.origin.Ask(question)
 	duration := time.Since(start)
-	b.stats = append(b.stats, duration)
+	b.stats.Add(duration)
 	return result, err
-}
-
-// PrintStats prints the statistics of the questions asked to the brain.
-// @todo #21:35min Move `PrintStats` method to the more properly organized abstraction.
-// Currently, we needed it in order to aggregate all the messages in the `stats` map, and then
-// print it. Since there is no `PrintStats` method in original `Brain`, it looks ugly when we call this
-// function on `Brain` instance in `refrax_client.go`. We should organize more proper abstraction
-// around the aggregation and printing of stats.
-func (b *MetricBrain) PrintStats() {
-	b.log.Info("Total messages asked: %d", len(b.stats))
-	for i, d := range b.stats {
-		b.log.Info("Brain finished asking question #%d in %s", i+1, d)
-	}
 }

--- a/internal/brain/metric_brain_test.go
+++ b/internal/brain/metric_brain_test.go
@@ -3,13 +3,12 @@ package brain
 import (
 	"testing"
 
-	"github.com/cqfn/refrax/internal/log"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMetricBrain_Ask_DelegatesToOrigin(t *testing.T) {
 	claim := "Give me good Java code!"
-	brain := NewMetricBrain(NewMock(), log.NewMock())
+	brain := NewMetricBrain(NewMock(), &Stats{})
 	response, err := brain.Ask(claim)
 	assert.NoError(t, err)
 	assert.Equal(t, claim, response)

--- a/internal/brain/stats.go
+++ b/internal/brain/stats.go
@@ -1,0 +1,20 @@
+package brain
+
+import "time"
+
+// Stats is a struct that contain interaction statistics between components.
+type Stats struct {
+	durations []time.Duration
+}
+
+// Add request timing.
+func (s *Stats) Add(duration time.Duration) {
+	s.durations = append(s.durations, duration)
+}
+
+// Durations retrieved all request timings.
+func (s *Stats) Durations() []time.Duration {
+	duplicate := make([]time.Duration, len(s.durations))
+	copy(duplicate, s.durations)
+	return duplicate
+}

--- a/internal/brain/stats_writer.go
+++ b/internal/brain/stats_writer.go
@@ -1,0 +1,6 @@
+package brain
+
+// StatsWriter writes Stats to a prarticular output.
+type StatsWriter interface {
+	Print(stats *Stats) error
+}

--- a/internal/brain/std_writer.go
+++ b/internal/brain/std_writer.go
@@ -1,0 +1,24 @@
+package brain
+
+import (
+	"github.com/cqfn/refrax/internal/log"
+)
+
+type stdWriter struct {
+	log log.Logger
+}
+
+// NewStdWriter creates an instance of StatsWriter that prints
+// statistics to the stdout.
+func NewStdWriter(logger log.Logger) StatsWriter {
+	return &stdWriter{log: logger}
+}
+
+func (s *stdWriter) Print(stats *Stats) error {
+	durations := stats.Durations()
+	s.log.Info("Total messages asked: %d", len(durations))
+	for i, d := range durations {
+		s.log.Info("Brain finished asking question #%d in %s", i+1, d)
+	}
+	return nil
+}

--- a/internal/brain/std_writer_test.go
+++ b/internal/brain/std_writer_test.go
@@ -1,0 +1,62 @@
+package brain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cqfn/refrax/internal/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStdWriterCreatesInstance(t *testing.T) {
+	w := NewStdWriter(log.NewMock())
+	require.NotNil(t, w)
+	assert.IsType(t, &stdWriter{}, w)
+}
+
+func TestStdWriterPrintLogsCorrectMessageCounts(t *testing.T) {
+	m := log.NewMock()
+	w := NewStdWriter(m)
+	stats := &Stats{}
+	stats.Add(1 * time.Millisecond)
+	stats.Add(2 * time.Millisecond)
+	stats.Add(3 * time.Millisecond)
+
+	err := w.Print(stats)
+
+	require.NoError(t, err)
+	entries := m.Messages
+	assert.Equal(t, "mock info: Total messages asked: 3", entries[0])
+	assert.Equal(t, "mock info: Brain finished asking question #1 in 1ms", entries[1])
+	assert.Equal(t, "mock info: Brain finished asking question #2 in 2ms", entries[2])
+	assert.Equal(t, "mock info: Brain finished asking question #3 in 3ms", entries[3])
+}
+
+func TestStdWriterPrintHandlesEmptyStats(t *testing.T) {
+	m := log.NewMock()
+	w := NewStdWriter(m)
+	stats := &Stats{}
+
+	err := w.Print(stats)
+
+	require.NoError(t, err)
+	entries := m.Messages
+	require.Len(t, entries, 1)
+	assert.Equal(t, "mock info: Total messages asked: 0", entries[0])
+}
+
+func TestStdWriterPrintLogsCorrectDurations(t *testing.T) {
+	m := log.NewMock()
+	w := NewStdWriter(m)
+	stats := &Stats{}
+	stats.Add(1 * time.Millisecond)
+	stats.Add(1 * time.Second)
+
+	err := w.Print(stats)
+
+	require.NoError(t, err)
+	entries := m.Messages
+	assert.Contains(t, entries[1], "mock info: Brain finished asking question #1 in 1ms")
+	assert.Contains(t, entries[2], "mock info: Brain finished asking question #2 in 1s")
+}

--- a/internal/client/refrax_client_test.go
+++ b/internal/client/refrax_client_test.go
@@ -17,7 +17,7 @@ func TestRefraxClient_Refactors_EmptyProject(t *testing.T) {
 	client := NewRefraxClient("none", "none", "")
 	origin := NewInMemoryProject(map[string]string{})
 
-	proj, err := client.Refactor(origin, false, log.NewMock())
+	proj, err := client.Refactor(origin, false, "std", "", log.NewMock())
 
 	assert.Equal(t, origin, proj, "Refactoring an empty project should return the same project")
 	assert.Error(t, err, "Expected an error when refactoring an empty project")
@@ -27,7 +27,7 @@ func TestRefraxClient_Refactors_EmptyProject(t *testing.T) {
 func TestRefraxClient_PrintsStatsIfEnabled(t *testing.T) {
 	client := NewRefraxClient("mock", "ABC", "")
 	logger := log.NewMock()
-	_, err := client.Refactor(SingleClassProject("Foo.java", "abstract class Foo {}"), true, logger)
+	_, err := client.Refactor(SingleClassProject("Foo.java", "abstract class Foo {}"), true, "std", "", logger)
 	assert.NoError(t, err)
 	assert.True(t, logMessageFoundWithText(logger, "Total messages asked"), "Expected total messages asked to be logged")
 	assert.True(t, logMessageFoundWithText(logger, "Brain finished asking"), "Expected interaction stats to be logged")


### PR DESCRIPTION
This PR refactors statistics handling by introducing `StatsWriter` interface with `std` and `csv` implementations.

Closes #39