### PR TITLE
refactor(#27): improve error handling and logging for empty projects

### DIFF
--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -2,15 +2,11 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/cqfn/refrax/internal/client"
-	"github.com/cqfn/refrax/internal/env"
-	"github.com/cqfn/refrax/internal/log"
 	"github.com/spf13/cobra"
 )
 
-func newRefactorCmd(params *Params) *cobra.Command {
+func newRefactorCmd(params *client.Params) *cobra.Command {
 	var output string
 	command := &cobra.Command{
 		Use:     "refactor [path]",
@@ -22,45 +18,12 @@ func newRefactorCmd(params *Params) *cobra.Command {
 			if len(args) > 0 {
 				path = args[0]
 			}
-			log.Debug("refactoring provider: %s", params.provider)
-			log.Debug("project path to refactor: %s", path)
-			var token string
-			if params.token != "" {
-				token = params.token
-			} else {
-				log.Info("token not provided, trying to find token in .env file")
-				token = env.Token(".env", params.provider)
-			}
-			log.Debug("using provided token: %s...", mask(token))
-			proj, err := project(path, output, params)
-			if err != nil {
-				return err
-			}
-			ref, err := client.Refactor(params.provider, token, proj, params.stats, params.format, params.soutput, log.Default(), params.playbook)
-			log.Debug("refactor result: %s", ref)
+			params.Input = path
+			params.Output = output
+			_, err := client.Refactor(params)
 			return err
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "", "output path for the refactored code")
 	return command
-}
-
-func project(path, output string, params *Params) (client.Project, error) {
-	if params.mock {
-		return client.NewMockProject(), nil
-	}
-	input := client.NewFilesystemProject(path)
-	if output != "" {
-		return client.NewMirrorProject(input, output)
-	}
-	return input, nil
-}
-
-func mask(token string) string {
-	n := len(token)
-	if n == 0 {
-		return ""
-	}
-	visible := min(n, 3)
-	return token[:visible] + strings.Repeat("*", n-visible)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,21 +4,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/cqfn/refrax/internal/log"
+	"github.com/cqfn/refrax/internal/client"
 	"github.com/spf13/cobra"
 )
-
-// Params holds the configuration parameters for Refrax commands.
-type Params struct {
-	provider string
-	token    string
-	playbook string
-	mock     bool
-	debug    bool
-	stats    bool
-	format   string
-	soutput  string
-}
 
 // Execute runs the root command and returns any error encountered.
 func Execute() error {
@@ -32,27 +20,21 @@ func Execute() error {
 // are: `aibolit`, `none`, etc. We should be able to pass multiple tools, for instance:
 // `--tools=aibolit,qulice`.
 func NewRootCmd(out, _ io.Writer) *cobra.Command {
-	var params Params
+	var params client.Params
 	root := &cobra.Command{
-		Use:   "refrax",
-		Short: "Refrax is an AI-powered refactoring agent for Java code",
-		Long:  "Refrax is an AI-powered refactoring agent for Java code. It communicates using the A2A protocol",
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
-			if params.debug {
-				log.Set(log.NewZerolog(out, "debug"))
-			} else {
-				log.Set(log.NewZerolog(out, "info"))
-			}
-		},
+		Use:              "refrax",
+		Short:            "Refrax is an AI-powered refactoring agent for Java code",
+		Long:             "Refrax is an AI-powered refactoring agent for Java code. It communicates using the A2A protocol",
+		PersistentPreRun: func(_ *cobra.Command, _ []string) { params.Log = out },
 	}
-	root.PersistentFlags().StringVarP(&params.provider, "ai", "a", "none", "AI provider to use (e.g., openai, deepseek, none, etc.)")
-	root.PersistentFlags().StringVarP(&params.token, "token", "t", "", "Token for the AI provider (if required)")
-	root.PersistentFlags().StringVar(&params.playbook, "playbook", "", "Path to a user-defined YAML playbook for AI integration.")
-	root.PersistentFlags().BoolVar(&params.mock, "mock", false, "Use mock project")
-	root.PersistentFlags().BoolVarP(&params.debug, "debug", "d", false, "print debug logs")
-	root.PersistentFlags().BoolVar(&params.stats, "stats", false, "Print internal interaction statistics")
-	root.PersistentFlags().StringVar(&params.format, "stats-format", "std", "Format for statistics output (e.g., std, csv, etc.)")
-	root.PersistentFlags().StringVar(&params.soutput, "stats-output", "stats", "Output path for statistics (default: stats)")
+	root.PersistentFlags().StringVarP(&params.Provider, "ai", "a", "none", "AI provider to use (e.g., openai, deepseek, none, etc.)")
+	root.PersistentFlags().StringVarP(&params.Token, "token", "t", "", "Token for the AI provider (if required)")
+	root.PersistentFlags().StringVar(&params.Playbook, "playbook", "", "Path to a user-defined YAML playbook for AI integration.")
+	root.PersistentFlags().BoolVar(&params.Mock, "mock", false, "Use mock project")
+	root.PersistentFlags().BoolVarP(&params.Debug, "debug", "d", false, "print debug logs")
+	root.PersistentFlags().BoolVar(&params.Stats, "stats", false, "Print internal interaction statistics")
+	root.PersistentFlags().StringVar(&params.Format, "stats-format", "std", "Format for statistics output (e.g., std, csv, etc.)")
+	root.PersistentFlags().StringVar(&params.Soutput, "stats-output", "stats", "Output path for statistics (default: stats)")
 	root.AddCommand(
 		newRefactorCmd(&params),
 		newStartCmd(),

--- a/internal/client/params.go
+++ b/internal/client/params.go
@@ -1,0 +1,35 @@
+package client
+
+import "io"
+
+// Params holds the configuration parameters for Refrax commands.
+type Params struct {
+	Provider string
+	Token    string
+	Playbook string
+	Mock     bool
+	Debug    bool
+	Stats    bool
+	Format   string
+	Soutput  string
+	Input    string
+	Output   string
+	Log      io.Writer
+}
+
+// NewMockParams creates a new Params object with mock settings.
+func NewMockParams() *Params {
+	return &Params{
+		Provider: "mock",
+		Token:    "ABC",
+		Playbook: "",
+		Mock:     true,
+		Debug:    false,
+		Stats:    false,
+		Format:   "std",
+		Soutput:  "stats",
+		Input:    "",
+		Output:   "",
+		Log:      io.Discard, // Default to discard if no logging is needed
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -42,7 +42,7 @@ func TestEndToEnd_Agents_FromCLI_WithoutAI_WithMockProject(t *testing.T) {
 
 	require.NoError(t, err, "Expected command to execute without error")
 	assert.Contains(t, capture.String(), "provider: none", "expect no AI provider to be used in output")
-	assert.Contains(t, capture.String(), "refactor result: [Main.java]", "expect refactored code to contain list of changed files")
+	assert.Contains(t, capture.String(), "refactoring is finished", "expect refactored code to contain list of changed files")
 }
 
 func TestEndToEnd_JavaRefactor_InlineVariable_WithoutAI(t *testing.T) {


### PR DESCRIPTION
This PR improves error handling and logging when no Java files are found during refactoring. It also consolidates configuration parameters into a single `Params` struct.

Related to #27