### PR TITLE
fix(#68): add error handling for unknown AI provider and update mock provider

### DIFF
--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -1,6 +1,8 @@
 // Package brain provides an interface and implementations for asking questions programmatically.
 package brain
 
+import "fmt"
+
 // Brain represents an interface for asking questions and receiving answers.
 type Brain interface {
 	Ask(question string) (string, error)
@@ -10,18 +12,22 @@ const deepseek = "deepseek"
 
 const openai = "openai"
 
+const mock = "mock"
+
 // New creates a new instance of Brain based on the provided provider and optional playbook strings.
-func New(provider, token string, playbook ...string) Brain {
+func New(provider, token string, playbook ...string) (Brain, error) {
 	switch provider {
 	case deepseek:
-		return NewDeepSeek(token)
+		return NewDeepSeek(token), nil
 	case openai:
-		return NewOpenAI(token)
-	default:
+		return NewOpenAI(token), nil
+	case mock:
 		if len(playbook) == 0 {
-			return NewMock()
+			return NewMock(), nil
 		}
-		return NewMock(playbook[0]) // Outdented as per lint suggestion.
+		return NewMock(playbook[0]), nil
+	default:
+		return nil, fmt.Errorf("unknown provider: %s", provider)
 	}
 }
 

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -3,33 +3,42 @@ package brain
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNew_WithDeepSeekProvider_ReturnsDeepSeekBrain(t *testing.T) {
 	token := "valid_token"
 
-	result := New(deepseek, token)
+	result, err := New(deepseek, token)
 
+	require.NoError(t, err, "Expected no error when creating DeepSeek brain")
 	_, ok := result.(*deepSeek)
 	require.True(t, ok, "Expected result to be of type DeepSeek")
-}
-
-func TestNew_WithUnknownProvider_ReturnsMockBrain(t *testing.T) {
-	provider := "unknown"
-	token := "any_token"
-
-	result := New(provider, token)
-
-	_, ok := result.(*MockBrain)
-	require.True(t, ok, "Expected result to be of type Mock")
 }
 
 func TestNew_WithOpenAIProvider_ReturnsOpenAIBrain(t *testing.T) {
 	token := "valid_openai_token"
 
-	result := New(openai, token)
+	result, err := New(openai, token)
 
+	require.NoError(t, err, "Expected no error when creating OpenAI brain")
 	_, ok := result.(*openAI)
 	require.True(t, ok, "Expected result to be of type OpenAI")
+}
+
+func TestNew_MockProviderNoPlaybook_ReturnsMockInstance(t *testing.T) {
+	result, err := New(mock, "test-token")
+
+	require.NoError(t, err)
+	_, ok := result.(*MockBrain)
+	require.True(t, ok, "Expected result to be of type Mock")
+}
+
+func TestNew_UnknownProvider_ReturnsError(t *testing.T) {
+	b, err := New("unknown", "test-token")
+
+	require.Error(t, err)
+	assert.Nil(t, b)
+	assert.Contains(t, err.Error(), "unknown provider: unknown")
 }

--- a/internal/client/refrax_client.go
+++ b/internal/client/refrax_client.go
@@ -53,7 +53,10 @@ func (c *RefraxClient) Refactor(proj Project) (Project, error) {
 	}
 	log.Debug("found %d classes in the project: %v", len(classes), classes)
 	counter := &stats.Stats{}
-	ai := mind(c.params, counter)
+	ai, err := mind(c.params, counter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AI instance: %w", err)
+	}
 
 	criticPort, err := protocol.FreePort()
 	if err != nil {
@@ -181,13 +184,12 @@ func printStats(p Params, s *stats.Stats) error {
 	return nil
 }
 
-func mind(p Params, s *stats.Stats) brain.Brain {
-	var ai brain.Brain
-	ai = brain.New(p.Provider, token(p), p.Playbook)
+func mind(p Params, s *stats.Stats) (brain.Brain, error) {
+	ai, err := brain.New(p.Provider, token(p), p.Playbook)
 	if p.Stats {
 		ai = brain.NewMetricBrain(ai, s)
 	}
-	return ai
+	return ai, err
 }
 
 func token(p Params) string {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -36,12 +36,12 @@ func TestEndToEnd_Agents_FromCLI_WithoutAI_WithMockProject(t *testing.T) {
 	capture := buff()
 	output := io.MultiWriter(capture, os.Stdout)
 	command := cmd.NewRootCmd(output, io.Discard)
-	command.SetArgs([]string{"refactor", "--ai=none", "--mock", "--debug", t.TempDir()})
+	command.SetArgs([]string{"refactor", "--ai=mock", "--mock", "--debug", t.TempDir()})
 
 	err := command.Execute()
 
 	require.NoError(t, err, "Expected command to execute without error")
-	assert.Contains(t, capture.String(), "provider: none", "expect no AI provider to be used in output")
+	assert.Contains(t, capture.String(), "provider: mock", "expect no AI provider to be used in output")
 	assert.Contains(t, capture.String(), "refactoring is finished", "expect refactored code to contain list of changed files")
 }
 
@@ -53,12 +53,12 @@ func TestEndToEnd_JavaRefactor_InlineVariable_WithoutAI(t *testing.T) {
 	output := io.MultiWriter(capture, os.Stdout)
 	command := cmd.NewRootCmd(output, io.Discard)
 	playbook := filepath.Join("test_data", "playbooks", "plain_main.yml")
-	command.SetArgs([]string{"refactor", "--ai=none", "--debug", fmt.Sprintf("--playbook=%s", playbook), jclass})
+	command.SetArgs([]string{"refactor", "--ai=mock", "--debug", fmt.Sprintf("--playbook=%s", playbook), jclass})
 
 	err := command.Execute()
 
 	require.NoError(t, err, "Expected command to execute without error")
-	assert.Contains(t, capture.String(), "provider: none", "expect no AI provider to be used in output")
+	assert.Contains(t, capture.String(), "provider: mock", "expect no AI provider to be used in output")
 	assertContent(t, jclass, expected)
 }
 
@@ -80,7 +80,7 @@ func TestEndToEnd_JavaRefactor_ManyJavaFilesProject(t *testing.T) {
 	output := io.MultiWriter(capture, os.Stdout)
 	command := cmd.NewRootCmd(output, io.Discard)
 	playbook := filepath.Join("test_data", "playbooks", "person.yml")
-	command.SetArgs([]string{"refactor", "--ai=none", "--debug", fmt.Sprintf("--playbook=%s", playbook), tmp})
+	command.SetArgs([]string{"refactor", "--ai=mock", "--debug", fmt.Sprintf("--playbook=%s", playbook), tmp})
 
 	err = command.Execute()
 
@@ -98,7 +98,7 @@ func TestEndToEnd_OuputOption_CopiesProject(t *testing.T) {
 	capture := buff()
 	output := io.MultiWriter(capture, os.Stdout)
 	command := cmd.NewRootCmd(output, io.Discard)
-	command.SetArgs([]string{"refactor", "--ai=none", "--debug", "--output=" + tmp, project})
+	command.SetArgs([]string{"refactor", "--ai=mock", "--debug", "--output=" + tmp, project})
 
 	err := command.Execute()
 
@@ -114,7 +114,7 @@ func TestEndToEnd_PrintsStatsIfEnabled(t *testing.T) {
 	capture := buff()
 	output := io.MultiWriter(capture, os.Stdout)
 	command := cmd.NewRootCmd(output, io.Discard)
-	command.SetArgs([]string{"refactor", "--stats", "--ai=none", "--output=" + tmp, project})
+	command.SetArgs([]string{"refactor", "--stats", "--ai=mock", "--output=" + tmp, project})
 
 	err := command.Execute()
 
@@ -132,7 +132,7 @@ func TestEndToEnd_PrintsStatisIfEnabled_ToCSV(t *testing.T) {
 		"--stats",
 		"--stats-format=csv",
 		"--stats-output=" + stats,
-		"--ai=none",
+		"--ai=mock",
 		"--output=" + tmp,
 		project,
 	})


### PR DESCRIPTION
This PR improves error handling for AI provider initialization and updates tests to use `mock` provider instead of `none`. Ensures proper validation of provider configuration.

Closes #68