### PR TITLE
fix(#75): implement context cancellation for server message processing

### DIFF
--- a/internal/critic/server.go
+++ b/internal/critic/server.go
@@ -1,6 +1,7 @@
 package critic
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -79,7 +80,16 @@ func (c *Critic) Handler(handler protocol.Handler) {
 	c.server.Handler(handler)
 }
 
-func (c *Critic) think(m *protocol.Message) (*protocol.Message, error) {
+func (c *Critic) think(ctx context.Context, m *protocol.Message) (*protocol.Message, error) {
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("context canceled: %w", ctx.Err())
+	default:
+		return c.thinkLong(m)
+	}
+}
+
+func (c *Critic) thinkLong(m *protocol.Message) (*protocol.Message, error) {
 	c.log.Debug("received message: #%s", m.MessageID)
 	var java string
 	var task string

--- a/internal/critic/server_test.go
+++ b/internal/critic/server_test.go
@@ -1,6 +1,7 @@
 package critic
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -113,7 +114,7 @@ func TestCriticThink_ReturnsMessage(t *testing.T) {
 		MessageID("msg-123").
 		Build()
 
-	response, err := critic.think(msg)
+	response, err := critic.think(context.Background(), msg)
 
 	require.NoError(t, err)
 	assert.Equal(t, msg.MessageID, response.MessageID)

--- a/internal/protocol/custom_server_test.go
+++ b/internal/protocol/custom_server_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -88,7 +89,7 @@ func testServer(t *testing.T) (server Server, port int, ready chan struct{}) {
 	return server, port, ready
 }
 
-func joke(msg *Message) (*Message, error) {
+func joke(_ context.Context, msg *Message) (*Message, error) {
 	log.Debug("Received message: %s", msg.MessageID)
 	if len(msg.Parts) == 0 || msg.Parts[0].PartKind() != PartKindText || msg.Parts[0].(*TextPart).Text != "tell me a joke" {
 		return nil, fmt.Errorf("unexpected message content, we expected 'tell me a joke', got: '%v'", msg.Parts[0].(*TextPart).Text)


### PR DESCRIPTION
This PR fixes server timeout issue in `refrax` by forcefully shutting down all the servers, preventing `context deadline exceeded` errors.

However, it creates another issue: Instead of gracefully `Shutdown` we just interrupt all the servers (`Close()`) 
https://stackoverflow.com/questions/79714562/how-to-cancel-long-running-tasks-when-a-go-http-server-is-shut-down

Fixes #75