### PR TITLE
feat(#84): add colored logging for agent differentiation

### DIFF
--- a/internal/critic/server.go
+++ b/internal/critic/server.go
@@ -44,7 +44,7 @@ Do not include any explanations, summaries, or extra text.
 
 // NewCritic creates and initializes a new instance of Critic.
 func NewCritic(ai brain.Brain, port int, tool ...Tool) *Critic {
-	logger := log.NewPrefixed("critic", log.Default())
+	logger := log.NewPrefixed("critic", log.NewColored(log.Default(), log.Cyan))
 	server := protocol.NewServer(agentCard(port), port)
 	critic := &Critic{
 		server: server,

--- a/internal/facilitator/server.go
+++ b/internal/facilitator/server.go
@@ -26,7 +26,7 @@ type Facilitator struct {
 
 // NewFacilitator creates a new instance of Facilitator to manage communication between agents.
 func NewFacilitator(ai brain.Brain, port, criticPort, fixerPort int) *Facilitator {
-	logger := log.NewPrefixed("facilitator", log.Default())
+	logger := log.NewPrefixed("facilitator", log.NewColored(log.Default(), log.Yellow))
 	logger.Debug("preparing server on port %d with ai provider %s", port, ai)
 	server := protocol.NewServer(agentCard(port), port)
 	facilitator := &Facilitator{
@@ -157,7 +157,7 @@ func (f *Facilitator) refactor(m *protocol.Message) (*protocol.Message, error) {
 				return nil, fmt.Errorf("failed to decode fixed file: %w", err)
 			}
 			changed += util.Diff(content, after)
-			f.log.Info("total number of fixed lines: %s", changed)
+			f.log.Info("total number of fixed lines: %d", changed)
 			f.log.Info("received fixed file from fixer, sending final response...")
 			response = response.Part(filePartResult.WithMetadata("class-name", class))
 		}

--- a/internal/fixer/server.go
+++ b/internal/fixer/server.go
@@ -35,7 +35,7 @@ const exampleNote = "This is an example of another refactored class. The same re
 
 // NewFixer creates a new Fixer instance with the provided AI brain and port.
 func NewFixer(ai brain.Brain, port int) *Fixer {
-	logger := log.NewPrefixed("fixer", log.Default())
+	logger := log.NewPrefixed("fixer", log.NewColored(log.Default(), log.Magenta))
 	logger.Debug("preparing server on port %d with ai provider %s", port, ai)
 	server := protocol.NewServer(agentCard(port), port)
 	fixer := &Fixer{

--- a/internal/log/colored.go
+++ b/internal/log/colored.go
@@ -1,0 +1,53 @@
+package log
+
+import (
+	"fmt"
+)
+
+type colored struct {
+	base  Logger
+	color Color
+}
+
+// Color represents a terminal color escape code.
+type Color string
+
+// Predefined terminal color escape codes.
+const (
+	Black   Color = "\033[30m" // Black color
+	Red     Color = "\033[31m" // Red color
+	Green   Color = "\033[32m" // Green color
+	Yellow  Color = "\033[33m" // Yellow color
+	Blue    Color = "\033[34m" // Blue color
+	Magenta Color = "\033[35m" // Magenta color
+	Cyan    Color = "\033[36m" // Cyan color
+	White   Color = "\033[37m" // White color
+)
+
+// NewColored wraps an existing Logger and applies ANSI color to its messages.
+func NewColored(base Logger, color Color) Logger {
+	return &colored{
+		base:  base,
+		color: color,
+	}
+}
+
+func (c *colored) Info(msg string, args ...any) {
+	c.base.Info(c.colorize(msg), args...)
+}
+
+func (c *colored) Debug(msg string, args ...any) {
+	c.base.Debug(c.colorize(msg), args...)
+}
+
+func (c *colored) Warn(msg string, args ...any) {
+	c.base.Warn(c.colorize(msg), args...)
+}
+
+func (c *colored) Error(msg string, args ...any) {
+	c.base.Error(c.colorize(msg), args...)
+}
+
+func (c *colored) colorize(msg string) string {
+	return fmt.Sprintf("%s%s\033[0m", c.color, msg)
+}

--- a/internal/log/colored_test.go
+++ b/internal/log/colored_test.go
@@ -1,0 +1,92 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockLogger struct {
+	infoMessages  []string
+	debugMessages []string
+	warnMessages  []string
+	errorMessages []string
+}
+
+func (m *mockLogger) Info(msg string, _ ...any) {
+	m.infoMessages = append(m.infoMessages, msg)
+}
+
+func (m *mockLogger) Debug(msg string, _ ...any) {
+	m.debugMessages = append(m.debugMessages, msg)
+}
+
+func (m *mockLogger) Warn(msg string, _ ...any) {
+	m.warnMessages = append(m.warnMessages, msg)
+}
+
+func (m *mockLogger) Error(msg string, _ ...any) {
+	m.errorMessages = append(m.errorMessages, msg)
+}
+
+func TestNewColored_Info(t *testing.T) {
+	m := &mockLogger{}
+	c := NewColored(m, Red)
+
+	require.NotNil(t, c)
+	c.Info("test message")
+
+	require.Len(t, m.infoMessages, 1)
+	assert.Equal(t, "\033[31mtest message\033[0m", m.infoMessages[0])
+}
+
+func TestNewColored_Debug(t *testing.T) {
+	m := &mockLogger{}
+	c := NewColored(m, Green)
+
+	require.NotNil(t, c)
+	c.Debug("debug message")
+
+	require.Len(t, m.debugMessages, 1)
+	assert.Equal(t, "\033[32mdebug message\033[0m", m.debugMessages[0])
+}
+
+func TestNewColored_Warn(t *testing.T) {
+	m := &mockLogger{}
+	c := NewColored(m, Yellow)
+
+	require.NotNil(t, c)
+	c.Warn("warn message")
+
+	require.Len(t, m.warnMessages, 1)
+	assert.Equal(t, "\033[33mwarn message\033[0m", m.warnMessages[0])
+}
+
+func TestNewColored_Error(t *testing.T) {
+	m := &mockLogger{}
+	c := NewColored(m, Blue)
+
+	require.NotNil(t, c)
+	c.Error("error message")
+
+	require.Len(t, m.errorMessages, 1)
+	assert.Equal(t, "\033[34merror message\033[0m", m.errorMessages[0])
+}
+
+func TestNewColored_MultipleMessages(t *testing.T) {
+	m := &mockLogger{}
+	c := NewColored(m, Magenta)
+
+	require.NotNil(t, c)
+	c.Info("info 1")
+	c.Info("info 2")
+	c.Warn("warn 1")
+
+	require.Len(t, m.infoMessages, 2)
+	require.Len(t, m.warnMessages, 1)
+
+	assert.Equal(t, "\033[35minfo 1\033[0m", m.infoMessages[0])
+	assert.Equal(t, "\033[35minfo 2\033[0m", m.infoMessages[1])
+	assert.Equal(t, "\033[35mwarn 1\033[0m", m.warnMessages[0])
+}


### PR DESCRIPTION
This PR adds colored logging to differentiate between agent types, with `critic` in cyan, `facilitator` in yellow, and `fixer` in magenta. Also fixes a format string in facilitator logs.

Fixes #84