### PR TITLE
feat(#90): add per-agent statistics tracking and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ If multiple sources are provided, the following priority order is applied (highe
 3. `TOKEN` environment variable (deprecated)
 4. `.env` file (`DEEPSEEK_TOKEN` > `TOKEN`)
 
+## Statistics
+
+To gather interaction statistics, you can use the following command:
+
+```sh
+refrax refactor . --ai=deepseek --stats --stats-format=csv --stats-output=stats.csv
+```
+
+This command generates a `stats.csv` file containing the interaction statistics.
+The `--stats-output` and `--stats-format` parameters are optional.
+If you omit them, `refrax` will output the statistics directly to the console.
+
 ## License
 
 Licensed under the [MIT](LICENSE.txt) License.

--- a/internal/stats/csv_writer_test.go
+++ b/internal/stats/csv_writer_test.go
@@ -19,7 +19,7 @@ func TestCSVWriter_Print_Success(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "output.csv")
 	w := NewCSVWriter(p)
-	var stats Stats
+	stats := Stats{Name: "test-stats"}
 	stats.LLMReq(1*time.Second, 0, 0, 0, 0)
 	stats.LLMReq(2*time.Second, 0, 0, 0, 0)
 	stats.LLMReq(3*time.Second, 0, 0, 0, 0)
@@ -33,8 +33,32 @@ func TestCSVWriter_Print_Success(t *testing.T) {
 	lines, err := csv.NewReader(file).ReadAll()
 	require.NoError(t, err)
 	require.Len(t, lines, 27)
-	assert.Equal(t, []string{"Metric", "Value"}, lines[0])
+	assert.Equal(t, []string{"metric", "test-stats"}, lines[0])
 	assert.Equal(t, []string{"Total LLM messages asked", "3"}, lines[1])
 	assert.Equal(t, []string{"Total LLM request duration", "6s"}, lines[2])
 	assert.Equal(t, []string{"Total LLM tokens", "0"}, lines[3])
+}
+
+func TestCSVWriter_PrintSeveral_Success(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "output.csv")
+	w := NewCSVWriter(p)
+	first := Stats{Name: "first-stats"}
+	first.LLMReq(3*time.Second, 0, 0, 0, 0)
+	second := Stats{Name: "second-stats"}
+	second.LLMReq(3*time.Second, 1, 1, 1, 1)
+
+	err := w.Print(&first, &second)
+
+	require.NoError(t, err)
+	file, err := os.Open(filepath.Clean(p))
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+	lines, err := csv.NewReader(file).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, lines, 27)
+	assert.Equal(t, []string{"metric", "first-stats", "second-stats"}, lines[0])
+	assert.Equal(t, []string{"Total LLM messages asked", "1", "1"}, lines[1])
+	assert.Equal(t, []string{"Total LLM request duration", "3s", "3s"}, lines[2])
+	assert.Equal(t, []string{"Total LLM tokens", "0", "2"}, lines[3])
 }

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,4 +12,131 @@ func TestTokens_Counts(t *testing.T) {
 	tokens, err := Tokens("Hello world!")
 	require.NoError(t, err, "Expected to create tokens without error")
 	assert.Equal(t, 3, tokens)
+}
+
+func TestStats_Add_Success(t *testing.T) {
+	s1 := &Stats{
+		Name:          "Stats1",
+		llmreq:        []time.Duration{time.Millisecond, 2 * time.Millisecond},
+		llmreqtokens:  10,
+		llmresptokens: 15,
+		llmreqbytes:   100,
+		llmrespbytes:  200,
+		a2areqs:       []time.Duration{3 * time.Millisecond},
+		a2areqtokens:  5,
+		a2aresptokens: 8,
+		a2areqbytes:   50,
+		a2arespbytes:  80,
+	}
+	s2 := &Stats{
+		Name:          "Stats2",
+		llmreq:        []time.Duration{500 * time.Microsecond},
+		llmreqtokens:  20,
+		llmresptokens: 25,
+		llmreqbytes:   300,
+		llmrespbytes:  400,
+		a2areqs:       []time.Duration{4 * time.Millisecond},
+		a2areqtokens:  15,
+		a2aresptokens: 18,
+		a2areqbytes:   60,
+		a2arespbytes:  90,
+	}
+	combined := s1.Add(s2)
+	require.NotNil(t, combined)
+	assert.Equal(t, "Stats1 + Stats2", combined.Name)
+	assert.Equal(t, []time.Duration{time.Millisecond, 2 * time.Millisecond, 500 * time.Microsecond}, combined.llmreq)
+	assert.Equal(t, []time.Duration{3 * time.Millisecond, 4 * time.Millisecond}, combined.a2areqs)
+	assert.Equal(t, 30, combined.llmreqtokens)
+	assert.Equal(t, 40, combined.llmresptokens)
+	assert.Equal(t, 400, combined.llmreqbytes)
+	assert.Equal(t, 600, combined.llmrespbytes)
+	assert.Equal(t, 20, combined.a2areqtokens)
+	assert.Equal(t, 26, combined.a2aresptokens)
+	assert.Equal(t, 110, combined.a2areqbytes)
+	assert.Equal(t, 170, combined.a2arespbytes)
+}
+
+func TestStats_Add_EmptyOther(t *testing.T) {
+	s := &Stats{
+		Name:          "Stats1",
+		llmreq:        []time.Duration{time.Millisecond},
+		llmreqtokens:  10,
+		llmresptokens: 15,
+		llmreqbytes:   100,
+		llmrespbytes:  200,
+		a2areqs:       []time.Duration{2 * time.Millisecond},
+		a2areqtokens:  5,
+		a2aresptokens: 8,
+		a2areqbytes:   50,
+		a2arespbytes:  80,
+	}
+	empty := &Stats{}
+
+	combined := s.Add(empty)
+
+	require.NotNil(t, combined)
+	assert.Equal(t, "Stats1 + ", combined.Name)
+	assert.Equal(t, []time.Duration{time.Millisecond}, combined.llmreq)
+	assert.Equal(t, []time.Duration{2 * time.Millisecond}, combined.a2areqs)
+	assert.Equal(t, 10, combined.llmreqtokens)
+	assert.Equal(t, 15, combined.llmresptokens)
+	assert.Equal(t, 100, combined.llmreqbytes)
+	assert.Equal(t, 200, combined.llmrespbytes)
+	assert.Equal(t, 5, combined.a2areqtokens)
+	assert.Equal(t, 8, combined.a2aresptokens)
+	assert.Equal(t, 50, combined.a2areqbytes)
+	assert.Equal(t, 80, combined.a2arespbytes)
+}
+
+func TestStats_Add_EmptySelf(t *testing.T) {
+	empty := &Stats{}
+	s := &Stats{
+		Name:          "Stats2",
+		llmreq:        []time.Duration{500 * time.Microsecond},
+		llmreqtokens:  20,
+		llmresptokens: 25,
+		llmreqbytes:   300,
+		llmrespbytes:  400,
+		a2areqs:       []time.Duration{4 * time.Millisecond},
+		a2areqtokens:  15,
+		a2aresptokens: 18,
+		a2areqbytes:   60,
+		a2arespbytes:  90,
+	}
+
+	combined := empty.Add(s)
+
+	require.NotNil(t, combined)
+	assert.Equal(t, " + Stats2", combined.Name)
+	assert.Equal(t, []time.Duration{500 * time.Microsecond}, combined.llmreq)
+	assert.Equal(t, []time.Duration{4 * time.Millisecond}, combined.a2areqs)
+	assert.Equal(t, 20, combined.llmreqtokens)
+	assert.Equal(t, 25, combined.llmresptokens)
+	assert.Equal(t, 300, combined.llmreqbytes)
+	assert.Equal(t, 400, combined.llmrespbytes)
+	assert.Equal(t, 15, combined.a2areqtokens)
+	assert.Equal(t, 18, combined.a2aresptokens)
+	assert.Equal(t, 60, combined.a2areqbytes)
+	assert.Equal(t, 90, combined.a2arespbytes)
+}
+
+func TestStats_Add_BothEmpty(t *testing.T) {
+	empty1 := &Stats{}
+	empty2 := &Stats{}
+
+	combined := empty1.Add(empty2)
+
+	combined.Name = "total"
+	require.NotNil(t, combined)
+	assert.Equal(t, "total", combined.Name)
+	assert.Empty(t, combined.llmreq)
+	assert.Empty(t, combined.a2areqs)
+	assert.Equal(t, 0, combined.llmreqtokens)
+	assert.Equal(t, 0, combined.llmresptokens)
+	assert.Equal(t, 0, combined.llmreqbytes)
+	assert.Equal(t, 0, combined.llmrespbytes)
+	assert.Equal(t, 0, combined.a2areqtokens)
+	assert.Equal(t, 0, combined.a2aresptokens)
+	assert.Equal(t, 0, combined.a2areqbytes)
+	assert.Equal(t, 0, combined.a2arespbytes)
 }

--- a/internal/stats/stats_writer.go
+++ b/internal/stats/stats_writer.go
@@ -2,5 +2,5 @@ package stats
 
 // Writer writes Stats to a prarticular output.
 type Writer interface {
-	Print(stats *Stats) error
+	Print(stats ...*Stats) error
 }

--- a/internal/stats/std_writer.go
+++ b/internal/stats/std_writer.go
@@ -14,10 +14,12 @@ func NewStdWriter(logger log.Logger) Writer {
 	return &stdWriter{log: logger}
 }
 
-func (s *stdWriter) Print(stats *Stats) error {
-	all := stats.Entries()
-	for _, v := range all {
-		s.log.Info("%s: %s", v.Title, v.Value)
+func (w *stdWriter) Print(stats ...*Stats) error {
+	for _, s := range stats {
+		all := s.Entries()
+		for _, v := range all {
+			w.log.Info("%s: %s", v.Title, v.Value)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds per-agent statistics tracking for `critic`, `fixer`, and `facilitator` components, including individual and aggregated metrics in CSV output. The stats can now be viewed separately for each agent or as a combined total.

Fixes #90