### PR TITLE
fix(#96): use class paths instead of names for identification

### DIFF
--- a/internal/client/refrax_client_test.go
+++ b/internal/client/refrax_client_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cqfn/refrax/internal/domain"
 	"github.com/cqfn/refrax/internal/project"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +18,7 @@ func TestRefraxClient_Creates_Successfully(t *testing.T) {
 
 func TestRefraxClient_Refactors_EmptyProject(t *testing.T) {
 	client := NewRefraxClient(NewMockParams())
-	origin := project.NewInMemory(map[string]string{})
+	origin := project.NewInMemory()
 
 	proj, err := client.Refactor(origin)
 
@@ -36,7 +37,7 @@ func TestRefraxClient_PrintsStatsIfEnabled(t *testing.T) {
 	out := bytes.Buffer{}
 	params.Log = NewSyncWriter(io.Writer(&out))
 	client := NewRefraxClient(params)
-	_, err := client.Refactor(project.SingleClass("Foo.java", "abstract class Foo {}"))
+	_, err := client.Refactor(project.NewInMemory(domain.NewClass("Foo.java", ".", "abstract class Foo {}")))
 	assert.NoError(t, err)
 	assert.Contains(t, out.String(), "Total LLM messages asked", "Expected total messages asked to be logged")
 }

--- a/internal/critic/server.go
+++ b/internal/critic/server.go
@@ -84,7 +84,7 @@ func (c *Critic) Review(class domain.Class) ([]domain.Suggestion, error) {
 	msg := protocol.NewMessage().
 		WithMessageID(uuid.NewString()).
 		AddPart(protocol.NewText("lint class")).
-		AddPart(protocol.NewFileBytes([]byte(class.Content())).WithMetadata("class-name", class.Name()))
+		AddPart(protocol.NewFileBytes([]byte(class.Content())).WithMetadata("class-name", class.Name()).WithMetadata("class-path", class.Path()))
 	resp, err := critic.SendMessage(protocol.NewMessageSendParams().WithMessage(msg))
 	if err != nil {
 		return nil, fmt.Errorf("failed to send message to critic: %w", err)
@@ -140,7 +140,7 @@ func (c *Critic) thinkLong(m *protocol.Message) (*protocol.Message, error) {
 	}
 	res := protocol.NewMessage().WithMessageID(m.MessageID)
 	suggestions := parseAnswer(answer)
-	suggestions = associated(suggestions, class.Name())
+	suggestions = associated(suggestions, class.Path())
 	logSuggestions(c.log, suggestions)
 	c.log.Info("found %d possible improvements", len(suggestions))
 	for _, suggestion := range suggestions {
@@ -173,9 +173,9 @@ func parseAnswer(answer string) []string {
 	return suggestions
 }
 
-func associated(suggestions []string, class string) []string {
+func associated(suggestions []string, classPath string) []string {
 	for i, suggestion := range suggestions {
-		suggestions[i] = fmt.Sprintf("%s: %s", class, suggestion)
+		suggestions[i] = fmt.Sprintf("%s: %s", classPath, suggestion)
 	}
 	return suggestions
 }

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1,6 +1,8 @@
 package domain
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Critic represents an interface to review a class and provide suggestions.
 type Critic interface {
@@ -28,6 +30,7 @@ type Task interface {
 type Class interface {
 	Name() string
 	Content() string
+	Path() string
 	SetContent(content string) error
 }
 
@@ -68,13 +71,15 @@ func NewTask(description string, classes []Class, parameters map[string]any) Tas
 
 type class struct {
 	content string
+	path    string
 	name    string
 }
 
 // NewClass creates a new Class instance with the given name and content.
-func NewClass(name, content string) Class {
+func NewClass(name, path, content string) Class {
 	return &class{
 		name:    name,
+		path:    path,
 		content: content,
 	}
 }
@@ -87,6 +92,11 @@ func (a *class) Content() string {
 // Name implements Class.
 func (a *class) Name() string {
 	return a.name
+}
+
+// Path implements Class.
+func (a *class) Path() string {
+	return a.path
 }
 
 type suggestion struct {

--- a/internal/project/filesystem_project.go
+++ b/internal/project/filesystem_project.go
@@ -68,6 +68,11 @@ func (c *FilesystemClass) Content() string {
 	return c.content
 }
 
+// Path returns the filesystem path of the Java class file.
+func (c *FilesystemClass) Path() string {
+	return c.path
+}
+
 // SetContent updates the content of the Java class file and writes it to the filesystem.
 func (c *FilesystemClass) SetContent(content string) error {
 	c.content = content

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -26,28 +26,15 @@ type InMemoryJavaClass struct {
 
 // NewMock creates a mock project with predefined content for testing purposes.
 func NewMock() Project {
-	mapping := map[string]string{
-		"Main.java": "public class Main {\n\tpublic static void main(String[] args) {\n\t\tString m = \"Hello, World\";\n\t\tSystem.out.println(m);\n\t}\n}\n",
-	}
-	return NewInMemory(mapping)
-}
-
-// SingleClass creates a project containing a single Java class with the provided name and content.
-func SingleClass(name, content string) Project {
-	mapping := map[string]string{
-		name: content,
-	}
-	return NewInMemory(mapping)
+	class := domain.NewClass("Main.java", ".", "public class Main {\n\tpublic static void main(String[] args) {\n\t\tString m = \"Hello, World\";\n\t\tSystem.out.println(m);\n\t}\n}\n")
+	return NewInMemory(class)
 }
 
 // NewInMemory creates a new in-memory project with the given map of file names to Java class content.
-func NewInMemory(files map[string]string) Project {
-	res := make(map[string]domain.Class, len(files))
-	for name, content := range files {
-		res[name] = &InMemoryJavaClass{
-			name:    name,
-			content: content,
-		}
+func NewInMemory(classes ...domain.Class) Project {
+	res := make(map[string]domain.Class, len(classes))
+	for _, class := range classes {
+		res[class.Path()] = class
 	}
 	return &InMemoryProject{
 		files: res,


### PR DESCRIPTION
This PR resolves the issue of handling classes with the same name by introducing class paths as unique identifiers throughout the codebase. The changes ensure proper identification and tracking of classes during refactoring operations.

Fixes #96