### PR TITLE
feat(#82): Add `Artifacts` Structure

### DIFF
--- a/internal/client/refrax_client.go
+++ b/internal/client/refrax_client.go
@@ -173,13 +173,22 @@ func refactor(f domain.Facilitator, p domain.Project, size int, ch chan<- refact
 	for _, c := range all {
 		before[c.Name()] = c
 	}
-	task := domain.NewTask("refactor the project", all, map[string]any{"max-size": fmt.Sprintf("%d", size)})
-	refactored, err := f.Refactor(task)
+	job := domain.Job{
+		Descr: &domain.Description{
+			Text: "refactor the project",
+			Meta: map[string]any{
+				"max-size": fmt.Sprintf("%d", size),
+			},
+		},
+		Classes: all,
+	}
+	artifacts, err := f.Refactor(&job)
 	if err != nil {
 		ch <- refactoring{err: fmt.Errorf("failed to refactor project %s: %w", p, err)}
 		close(ch)
 		return
 	}
+	refactored := artifacts.Classes
 	log.Info("refactored %d classes in project %s", len(refactored), p)
 	for _, c := range refactored {
 		log.Debug("rececived refactored class: ", c)

--- a/internal/critic/server_test.go
+++ b/internal/critic/server_test.go
@@ -129,5 +129,5 @@ func TestCriticThink_ReturnsMessage(t *testing.T) {
 	response, err := critic.think(context.Background(), msg)
 
 	require.NoError(t, err)
-	assert.Equal(t, msg.MessageID, response.MessageID)
+	require.NotNil(t, response)
 }

--- a/internal/domain/a2a.go
+++ b/internal/domain/a2a.go
@@ -2,13 +2,54 @@ package domain
 
 import (
 	"fmt"
-	"strconv"
 
-	"github.com/cqfn/refrax/internal/log"
 	"github.com/cqfn/refrax/internal/protocol"
 	"github.com/cqfn/refrax/internal/util"
 	"github.com/google/uuid"
 )
+
+const (
+	typeClass      = "class"
+	typeSuggestion = "suggestion"
+	typeExample    = "example"
+)
+
+func UnmarshalArtifacts(msg *protocol.Message) (*Artifacts, error) {
+	if len(msg.Parts) == 0 {
+		return nil, fmt.Errorf("message has no parts")
+	}
+	artifacts := &Artifacts{}
+	descr, err := UnmarshalDescription(msg.Parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal description: %w", err)
+	}
+	artifacts.Descr = descr
+	classes := make([]Class, 0)
+	suggestions := make([]Suggestion, 0)
+	for _, part := range msg.Parts[1:] {
+		metas := part.Metadata()
+		t := metas["type"]
+		switch t {
+		case typeClass:
+			c, err := UnmarshalClass(part)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal class: %w", err)
+			}
+			classes = append(classes, c)
+		case typeSuggestion:
+			s, err := UnmarshalSuggestion(part)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal suggestion: %w", err)
+			}
+			suggestions = append(suggestions, s)
+		default:
+			return nil, fmt.Errorf("unknown part type %s", t)
+		}
+	}
+	artifacts.Classes = classes
+	artifacts.Suggestions = suggestions
+	return artifacts, nil
+}
 
 func UnmarshalJob(msg *protocol.Message) (*Job, error) {
 	if len(msg.Parts) == 0 {
@@ -27,19 +68,19 @@ func UnmarshalJob(msg *protocol.Message) (*Job, error) {
 		metas := part.Metadata()
 		t := metas["type"]
 		switch t {
-		case "class":
+		case typeClass:
 			c, err := UnmarshalClass(part)
 			if err != nil {
 				return nil, fmt.Errorf("failed to unmarshal class: %w", err)
 			}
 			classes = append(classes, c)
-		case "example":
+		case typeExample:
 			e, err := UnmarshalClass(part)
 			if err != nil {
 				return nil, fmt.Errorf("failed to unmarshal example class: %w", err)
 			}
 			examples = append(examples, e)
-		case "suggestion":
+		case typeSuggestion:
 			s, err := UnmarshalSuggestion(part)
 			if err != nil {
 				return nil, fmt.Errorf("failed to unmarshal suggestion: %w", err)
@@ -87,7 +128,7 @@ func UnmarshalDescription(part protocol.Part) (*Description, error) {
 	descr := part.(*protocol.TextPart).Text
 	res := Description{
 		Text: descr,
-		meta: part.Metadata(),
+		Meta: part.Metadata(),
 	}
 	return &res, nil
 }
@@ -102,7 +143,7 @@ func (j *Job) Marshal() *protocol.MessageSendParams {
 			if class == nil {
 				continue
 			}
-			msg.AddPart(MarshalClass(class, "class"))
+			msg.AddPart(MarshalClass(class, typeClass))
 		}
 	}
 	if len(j.Suggestions) > 0 {
@@ -118,7 +159,31 @@ func (j *Job) Marshal() *protocol.MessageSendParams {
 			if example == nil {
 				continue
 			}
-			msg.AddPart(MarshalClass(example, "example"))
+			msg.AddPart(MarshalClass(example, typeExample))
+		}
+	}
+	return protocol.NewMessageSendParams().WithMessage(msg)
+}
+
+func (a *Artifacts) Marshal() *protocol.MessageSendParams {
+	msg := protocol.NewMessage().WithMessageID(uuid.NewString())
+	if a.Descr != nil {
+		msg.AddPart(a.Descr.Marshal())
+	}
+	if len(a.Classes) > 0 {
+		for _, class := range a.Classes {
+			if class == nil {
+				continue
+			}
+			msg.AddPart(MarshalClass(class, typeClass))
+		}
+	}
+	if len(a.Suggestions) > 0 {
+		for _, suggestion := range a.Suggestions {
+			if suggestion == nil {
+				continue
+			}
+			msg.AddPart(MarshalSuggestion(suggestion))
 		}
 	}
 	return protocol.NewMessageSendParams().WithMessage(msg)
@@ -126,7 +191,7 @@ func (j *Job) Marshal() *protocol.MessageSendParams {
 
 func (d *Description) Marshal() protocol.Part {
 	part := protocol.NewText(d.Text)
-	for k, v := range d.meta {
+	for k, v := range d.Meta {
 		part = part.WithMetadata(k, v)
 	}
 	return part
@@ -140,128 +205,5 @@ func MarshalClass(c Class, t string) protocol.Part {
 }
 
 func MarshalSuggestion(s Suggestion) protocol.Part {
-	return protocol.NewText(s.Text()).WithMetadata("type", "suggestion")
-}
-
-// TaskToMsg converts a Task object to a protocol.Message.
-func TaskToMsg(task Task) *protocol.Message {
-	param, ok := task.Param("max-size")
-	if !ok {
-		param = "200"
-	}
-	size, err := strconv.Atoi(param)
-	if err != nil {
-		panic(err)
-	}
-	msg := protocol.NewMessage().
-		WithMessageID(uuid.NewString()).
-		AddPart(protocol.NewText(task.Description()).WithMetadata("max-size", size))
-	all := task.Classes()
-	for _, class := range all {
-		name := class.Name()
-		path := class.Path()
-		msg = msg.AddPart(protocol.NewFileBytes([]byte(class.Content())).WithMetadata("class-name", name).WithMetadata("class-path", path))
-	}
-	return msg
-}
-
-// RespToClasses converts a protocol.JSONRPCResponse to a slice of Class objects.
-func RespToClasses(resp *protocol.JSONRPCResponse) ([]Class, error) {
-	parts := resp.Result.(*protocol.Message).Parts
-	log.Debug("received %d parts in refactoring response", len(parts))
-	classes := make([]Class, 0, len(parts))
-	for _, p := range parts {
-		kind := p.PartKind()
-		if kind == protocol.PartKindFile {
-			log.Debug("received file part %v", p)
-			classname := p.Metadata()["class-name"]
-			path := fmt.Sprintf("%v", p.Metadata()["class-path"])
-			bytes := p.(*protocol.FilePart).File.(protocol.FileWithBytes).Bytes
-			decoded, err := util.DecodeFile(bytes)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode refactored class %s: %w", classname, err)
-			}
-			class := NewClass(fmt.Sprintf("%v", classname), path, decoded)
-			classes = append(classes, class)
-		}
-	}
-	return classes, nil
-}
-
-// ClassesToMsg compiles a protocol message from a list of classes.
-func ClassesToMsg(classes []Class) *protocol.Message {
-	msg := protocol.NewMessage()
-	for _, v := range classes {
-		msg.AddPart(protocol.NewFileBytes([]byte(v.Content())).WithMetadata("class-name", v.Name()))
-	}
-	return msg
-}
-
-// RespToSuggestions converts a protocol.JSONRPCResponse to a slice of Suggestion objects.
-func RespToSuggestions(resp *protocol.JSONRPCResponse) []Suggestion {
-	criticMessage := resp.Result.(*protocol.Message)
-	suggestions := make([]Suggestion, 0, len(criticMessage.Parts))
-	for _, part := range criticMessage.Parts {
-		if part.PartKind() == protocol.PartKindText {
-			suggestion := NewSuggestion(part.(*protocol.TextPart).Text)
-			suggestions = append(suggestions, suggestion)
-		}
-	}
-	return suggestions
-}
-
-// RespToClass converts a JSONRPCResponse into a Class, decoding file parts as needed.
-func RespToClass(resp *protocol.JSONRPCResponse) (Class, error) {
-	part := resp.Result.(*protocol.Message).Parts[0]
-	if part.PartKind() == protocol.PartKindFile {
-		filePart := part.(*protocol.FilePart)
-		decoded, err := util.DecodeFile(filePart.File.(protocol.FileWithBytes).Bytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode file part: %w", err)
-		}
-		meta := filePart.Metadata()
-		name := meta["class-name"]
-		if name == nil {
-			return nil, fmt.Errorf("file part has no class name metadata")
-		}
-		path := meta["class-path"]
-		if path == nil {
-			return nil, fmt.Errorf("file part has no class path metadata")
-		}
-		log.Debug("decoded class name: %s, path: ", name, path)
-		return NewClass(fmt.Sprintf("%v", name), fmt.Sprintf("%v", path), decoded), nil
-	}
-	return nil, fmt.Errorf("expected file part, got %s", part.PartKind())
-}
-
-// MsgToTask parses a task from a protocol message.
-func MsgToTask(msg *protocol.Message) (Task, error) {
-	if len(msg.Parts) == 0 {
-		return nil, fmt.Errorf("message has no parts")
-	}
-	part := msg.Parts[0]
-	if part.PartKind() != protocol.PartKindText {
-		return nil, fmt.Errorf("expected text part, got %s", part.PartKind())
-	}
-	descr := part.(*protocol.TextPart).Text
-	params := part.Metadata()
-	classes := make([]Class, 0)
-	for _, v := range msg.Parts[1:] {
-		if v.PartKind() != protocol.PartKindFile {
-			continue
-		}
-		filePart := v.(*protocol.FilePart)
-		decoded, err := util.DecodeFile(filePart.File.(protocol.FileWithBytes).Bytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode file part: %w", err)
-		}
-		meta := v.Metadata()
-		class := NewClass(fmt.Sprintf("%v", meta["class-name"]), fmt.Sprintf("%v", meta["class-path"]), decoded)
-		classes = append(classes, class)
-	}
-	return &task{
-		descr:      descr,
-		classes:    classes,
-		parameters: params,
-	}, nil
+	return protocol.NewText(s.Text()).WithMetadata("type", typeSuggestion)
 }

--- a/internal/domain/a2a_test.go
+++ b/internal/domain/a2a_test.go
@@ -11,7 +11,7 @@ func TestMarshalAndUnmarshalJob(t *testing.T) {
 	before := &Job{
 		Descr: &Description{
 			Text: "Test Job",
-			meta: map[string]any{"key": "value"},
+			Meta: map[string]any{"key": "value"},
 		},
 		Classes: []Class{
 			NewClass("TestClass", "test/path/TestClass.java", "public class TestClass {}"),

--- a/internal/domain/agents.go
+++ b/internal/domain/agents.go
@@ -2,22 +2,22 @@ package domain
 
 // Facilitator represents an interface to refactor tasks into multiple classes.
 type Facilitator interface {
-	Refactor(task Task) ([]Class, error)
+	Refactor(job *Job) (*Artifacts, error)
 }
 
 // Critic represents an interface to review a class and provide suggestions.
 type Critic interface {
-	Review(job *Job) ([]Suggestion, error)
+	Review(job *Job) (*Artifacts, error)
 }
 
 // Fixer represents an interface to fix a class based on suggestions and an example.
 type Fixer interface {
-	Fix(job *Job) (Class, error)
+	Fix(job *Job) (*Artifacts, error)
 }
 
 // Reviewer represents an interface for a reviewer that can review changes made.
 type Reviewer interface {
-	Review() ([]Suggestion, error)
+	Review() (*Artifacts, error)
 }
 
 type Job struct {
@@ -27,9 +27,23 @@ type Job struct {
 	Examples    []Class
 }
 
+type Artifacts struct {
+	Descr       *Description
+	Classes     []Class
+	Suggestions []Suggestion
+}
+
 type Description struct {
 	Text string
-	meta map[string]any
+	Meta map[string]any
+}
+
+func (j *Job) Param(key string) (any, bool) {
+	if j.Descr == nil || j.Descr.Meta == nil {
+		return nil, false
+	}
+	res, ok := j.Descr.Meta[key]
+	return res, ok
 }
 
 func (j *Job) FirstClass() Class {

--- a/internal/reviewer/agent.go
+++ b/internal/reviewer/agent.go
@@ -19,7 +19,7 @@ type agent struct {
 	ai     brain.Brain
 }
 
-func (a *agent) Review() ([]domain.Suggestion, error) {
+func (a *agent) Review() (*domain.Artifacts, error) {
 	var res []domain.Suggestion
 	for _, cmd := range a.cmds {
 		suggestions, err := a.runCmd(cmd)
@@ -28,7 +28,11 @@ func (a *agent) Review() ([]domain.Suggestion, error) {
 		}
 		res = append(res, suggestions...)
 	}
-	return res, nil
+	artifacts := &domain.Artifacts{
+		Descr:       &domain.Description{Text: "suggestions based on command outputs"},
+		Suggestions: res,
+	}
+	return artifacts, nil
 }
 
 func (a *agent) runCmd(cmd string) ([]domain.Suggestion, error) {


### PR DESCRIPTION
In this PR I've added `Artifacts` structure that should unify all the agent responses and eliminate a bunch of boilerplate code.

Related to #82