### PR TITLE
feat(#82): Extend 'Suggestion' Structure With Class Reference

### DIFF
--- a/internal/client/refrax_client.go
+++ b/internal/client/refrax_client.go
@@ -138,7 +138,7 @@ func (c *RefraxClient) Refactor(proj domain.Project) (domain.Project, error) {
 	<-rvwr.Ready()
 
 	log.Info("all servers are ready: facilitator %d, critic %d, fixer %d, reviewer %d", facilitatorPort, criticPort, fixerPort, reviewerPort)
-	log.Info("begin refactoring")
+	log.Info("begin refactoring for project %s with %d classes", proj, len(classes))
 	ch := make(chan refactoring, len(classes))
 	go refactor(fclttor, proj, c.params.MaxSize, ch)
 	for range len(classes) {
@@ -184,6 +184,7 @@ func refactor(f domain.Facilitator, p domain.Project, size int, ch chan<- refact
 	}
 	artifacts, err := f.Refactor(&job)
 	if err != nil {
+		log.Error("failed to refactor project %s: %v", p, err)
 		ch <- refactoring{err: fmt.Errorf("failed to refactor project %s: %w", p, err)}
 		close(ch)
 		return

--- a/internal/client/refrax_client_test.go
+++ b/internal/client/refrax_client_test.go
@@ -36,7 +36,7 @@ func TestRefraxClient_PrintsStatsIfEnabled(t *testing.T) {
 	out := bytes.Buffer{}
 	params.Log = NewSyncWriter(io.Writer(&out))
 	client := NewRefraxClient(params)
-	_, err := client.Refactor(domain.NewInMemory(domain.NewClass("Foo.java", ".", "abstract class Foo {}")))
+	_, err := client.Refactor(domain.NewInMemory(domain.NewInMemoryClass("Foo.java", ".", "abstract class Foo {}")))
 	assert.NoError(t, err)
 	assert.Contains(t, out.String(), "Total LLM messages asked", "Expected total messages asked to be logged")
 }

--- a/internal/critic/agent.go
+++ b/internal/critic/agent.go
@@ -1,0 +1,98 @@
+package critic
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cqfn/refrax/internal/brain"
+	"github.com/cqfn/refrax/internal/domain"
+	"github.com/cqfn/refrax/internal/log"
+	"github.com/cqfn/refrax/internal/tool"
+)
+
+type agent struct {
+	brain brain.Brain
+	log   log.Logger
+	tools []tool.Tool
+}
+
+const notFound = "No suggestions found"
+
+const prompt = `Analyze the following Java code:
+
+{{code}}
+
+Identify possible improvements or flaws such as:
+
+* grammar and spelling mistakes in comments,
+* variables that can be inlined or removed without changing functionality,
+* unnecessary comments inside methods,
+* redundant code.
+
+Don't suggest any changes that would alter the functionality of the code.
+Don't suggest any changes that would require moving code parts between files (like extract class or extract an interface).
+Don't suggest method renaming or class renaming.
+
+Keep in mind the following imperfections with Java code, identified by automated static analysis system:
+
+{{imperfections}}
+
+Respond with a few most relevant and important suggestion for improvement, formatted as a few lines of text. 
+If there are no suggestions or they are insignificant, respond with "{{not-found}}".
+Do not include any explanations, summaries, or extra text.
+`
+
+// Review sends the provided Java class to the Critic for analysis and returns suggested improvements.
+func (c *agent) Review(job *domain.Job) (*domain.Artifacts, error) {
+	class := job.Classes[0]
+	c.log.Info("received class %q for analysis", class.Name())
+	replacer := strings.NewReplacer(
+		"{{code}}", class.Content(),
+		"{{imperfections}}", tool.NewCombined(c.tools...).Imperfections(),
+		"{{not-found}}", notFound,
+	)
+	answer, err := c.brain.Ask(replacer.Replace(prompt))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get answer from brain: %w", err)
+	}
+	suggestions := c.associated(parseAnswer(answer), class.Path())
+	logSuggestions(c.log, suggestions)
+	artifacts := domain.Artifacts{
+		Descr: &domain.Description{
+			Text: fmt.Sprintf("Critique for class %s", class.Name()),
+		},
+		Suggestions: suggestions,
+	}
+	return &artifacts, nil
+}
+
+func logSuggestions(logger log.Logger, suggestions []domain.Suggestion) {
+	for i, suggestion := range suggestions {
+		logger.Info("#%d: %s", i+1, suggestion)
+	}
+}
+
+func parseAnswer(answer string) []string {
+	lines := strings.Split(strings.TrimSpace(answer), "\n")
+	var suggestions []string
+	for _, line := range lines {
+		suggestion := strings.TrimSpace(line)
+		if suggestion != "" {
+			suggestions = append(suggestions, suggestion)
+		}
+	}
+	return suggestions
+}
+
+func (a *agent) associated(suggestions []string, class string) []domain.Suggestion {
+	res := make([]domain.Suggestion, 0)
+	for i, suggestion := range suggestions {
+		if strings.EqualFold(suggestion, notFound) {
+			a.log.Info("no suggestions found for the class #%d: %s", i+1, class)
+		} else {
+			res = append(res, *domain.NewSuggestion(suggestion, class))
+		}
+	}
+	a.log.Info("total suggestions associated with class %s: %d", class, len(res))
+	return res
+}

--- a/internal/critic/server_test.go
+++ b/internal/critic/server_test.go
@@ -61,7 +61,7 @@ func TestNewCritic_Success(t *testing.T) {
 
 	critic := NewCritic(ai, 18081)
 	require.NotNil(t, critic)
-	assert.Equal(t, ai, critic.brain)
+	assert.Equal(t, ai, critic.agent.brain)
 }
 
 func TestCriticStart_Success(t *testing.T) {

--- a/internal/domain/a2a_test.go
+++ b/internal/domain/a2a_test.go
@@ -14,16 +14,16 @@ func TestMarshalAndUnmarshalJob(t *testing.T) {
 			Meta: map[string]any{"key": "value"},
 		},
 		Classes: []Class{
-			NewClass("TestClass", "test/path/TestClass.java", "public class TestClass {}"),
-			NewClass("AnotherClass", "test/path/AnotherClass.java", "public class AnotherClass {}"),
+			NewInMemoryClass("TestClass", "test/path/TestClass.java", "public class TestClass {}"),
+			NewInMemoryClass("AnotherClass", "test/path/AnotherClass.java", "public class AnotherClass {}"),
 		},
 		Examples: []Class{
-			NewClass("ExampleClass", "test/path/ExampleClass.java", "public class ExampleClass {}"),
+			NewInMemoryClass("ExampleClass", "test/path/ExampleClass.java", "public class ExampleClass {}"),
 		},
 		Suggestions: []Suggestion{
-			NewSuggestion("Improve TestClass"),
-			NewSuggestion("Add documentation to AnotherClass"),
-			NewSuggestion("Refactor ExampleClass"),
+			*NewSuggestion("Improve TestClass", "test/path/TestClass.java"),
+			*NewSuggestion("Add documentation to AnotherClass", "test/path/AnotherClass.java"),
+			*NewSuggestion("Refactor ExampleClass", "test/path/ExampleClass.java"),
 		},
 	}
 	after, err := UnmarshalJob(before.Marshal().Message)

--- a/internal/domain/agents.go
+++ b/internal/domain/agents.go
@@ -1,5 +1,7 @@
 package domain
 
+import "fmt"
+
 // Facilitator represents an interface to refactor tasks into multiple classes.
 type Facilitator interface {
 	Refactor(job *Job) (*Artifacts, error)
@@ -27,6 +29,14 @@ type Job struct {
 	Examples    []Class
 }
 
+func (j *Job) Param(key string) (any, bool) {
+	if j.Descr == nil || j.Descr.Meta == nil {
+		return nil, false
+	}
+	res, ok := j.Descr.Meta[key]
+	return res, ok
+}
+
 type Artifacts struct {
 	Descr       *Description
 	Classes     []Class
@@ -38,17 +48,11 @@ type Description struct {
 	Meta map[string]any
 }
 
-func (j *Job) Param(key string) (any, bool) {
-	if j.Descr == nil || j.Descr.Meta == nil {
-		return nil, false
-	}
-	res, ok := j.Descr.Meta[key]
-	return res, ok
+type Suggestion struct {
+	ClassPath string
+	Text      string
 }
 
-func (j *Job) FirstClass() Class {
-	if len(j.Classes) == 0 {
-		return nil
-	}
-	return j.Classes[0]
+func (s *Suggestion) String() string {
+	return fmt.Sprintf("suggestion for %s: %s", s.ClassPath, s.Text)
 }

--- a/internal/domain/class.go
+++ b/internal/domain/class.go
@@ -1,5 +1,11 @@
 package domain
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
 // Class represents a code or text entity with a name and content.
 type Class interface {
 	Name() string
@@ -8,15 +14,15 @@ type Class interface {
 	SetContent(content string) error
 }
 
-type class struct {
+type memClass struct {
 	content string
 	path    string
 	name    string
 }
 
-// NewClass creates a new Class instance with the given name and content.
-func NewClass(name, path, content string) Class {
-	return &class{
+// NewInMemoryClass creates a new Class instance with the given name and content.
+func NewInMemoryClass(name, path, content string) Class {
+	return &memClass{
 		name:    name,
 		path:    path,
 		content: content,
@@ -24,21 +30,61 @@ func NewClass(name, path, content string) Class {
 }
 
 // Content implements Class.
-func (a *class) Content() string {
+func (a *memClass) Content() string {
 	return a.content
 }
 
 // Name implements Class.
-func (a *class) Name() string {
+func (a *memClass) Name() string {
 	return a.name
 }
 
 // Path implements Class.
-func (a *class) Path() string {
+func (a *memClass) Path() string {
 	return a.path
 }
 
 // SetContent updates the content of the class.
-func (a *class) SetContent(_ string) error {
-	panic("SetContent is not implemented for a2a class")
+func (a *memClass) SetContent(content string) error {
+	a.content = content
+	return nil
+}
+
+// FSClass represents a Java class file stored in the filesystem.
+type FSClass struct {
+	name string
+	path string
+}
+
+// NewFSClass creates a new FilesystemClass with the given name, path, and content.
+func NewFSClass(name, path string) *FSClass {
+	return &FSClass{
+		name: name,
+		path: path,
+	}
+}
+
+func (c *FSClass) Name() string {
+	return c.name
+}
+
+func (c *FSClass) Path() string {
+	return c.path
+}
+
+func (c *FSClass) Content() string {
+	content, readErr := os.ReadFile(filepath.Clean(c.path))
+	if readErr != nil {
+		panic(readErr)
+	}
+	return string(content)
+}
+
+// SetContent updates the content of the Java class file and writes it to the filesystem.
+func (c *FSClass) SetContent(content string) error {
+	err := os.WriteFile(c.path, []byte(content), 0o600)
+	if err != nil {
+		return fmt.Errorf("error writing content to file %s: %w", c.path, err)
+	}
+	return nil
 }

--- a/internal/domain/filesystem_project.go
+++ b/internal/domain/filesystem_project.go
@@ -7,33 +7,27 @@ import (
 	"strings"
 )
 
-// FilesystemProject represents a project stored in the filesystem.
-type FilesystemProject struct {
+// FSProj represents a project stored in the filesystem.
+type FSProj struct {
 	path string
 }
 
 // NewFilesystem creates a new FilesystemProject with the given path.
-func NewFilesystem(path string) *FilesystemProject {
-	return &FilesystemProject{path: path}
+func NewFilesystem(path string) *FSProj {
+	return &FSProj{path: path}
 }
 
 // Classes retrieves all Java classes in the project directory and its subdirectories.
-func (p *FilesystemProject) Classes() ([]Class, error) {
+func (p *FSProj) Classes() ([]Class, error) {
 	var classes []Class
 	err := filepath.Walk(p.path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".java") {
-			content, readErr := os.ReadFile(filepath.Clean(path))
-			if readErr != nil {
-				return readErr
-			}
-			classes = append(classes, &FilesystemClass{
-				content: string(content),
-				name:    strings.TrimSuffix(info.Name(), ".java"),
-				path:    path,
-			})
+		ext := ".java"
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ext) {
+			c := NewFSClass(strings.TrimSuffix(info.Name(), ext), path)
+			classes = append(classes, c)
 		}
 		return nil
 	})
@@ -44,47 +38,6 @@ func (p *FilesystemProject) Classes() ([]Class, error) {
 }
 
 // String returns the string representation of the FilesystemProject.
-func (p *FilesystemProject) String() string {
+func (p *FSProj) String() string {
 	return fmt.Sprintf("[%s]", p.path)
-}
-
-// FilesystemClass represents a Java class file stored in the filesystem.
-type FilesystemClass struct {
-	name    string
-	content string
-	path    string
-}
-
-// NewFilesystemClass creates a new FilesystemClass with the given name, path, and content.
-func NewFilesystemClass(name, path, content string) *FilesystemClass {
-	return &FilesystemClass{
-		name:    name,
-		path:    path,
-		content: content,
-	}
-}
-
-// Name returns the name of the Java class.
-func (c *FilesystemClass) Name() string {
-	return c.name
-}
-
-// Content returns the content of the Java class file.
-func (c *FilesystemClass) Content() string {
-	return c.content
-}
-
-// Path returns the filesystem path of the Java class file.
-func (c *FilesystemClass) Path() string {
-	return c.path
-}
-
-// SetContent updates the content of the Java class file and writes it to the filesystem.
-func (c *FilesystemClass) SetContent(content string) error {
-	c.content = content
-	err := os.WriteFile(c.path, []byte(content), 0o600)
-	if err != nil {
-		return fmt.Errorf("error writing content to file %s: %w", c.path, err)
-	}
-	return nil
 }

--- a/internal/domain/filesystem_project_test.go
+++ b/internal/domain/filesystem_project_test.go
@@ -59,21 +59,6 @@ func TestFilesystemProject_Classes_NonJavaFilesIgnored(t *testing.T) {
 	assert.Empty(t, classes)
 }
 
-func TestFilesystemProject_Classes_ErrorReadingFile(t *testing.T) {
-	SkipOnWindows(t)
-	tempDir := t.TempDir()
-	filePath := filepath.Join(tempDir, "Class1.java")
-	require.NoError(t, os.WriteFile(filePath, []byte("class Class1 {}"), 0o600))
-	require.NoError(t, os.Chmod(filePath, 0o200)) // Write-only
-
-	project := NewFilesystem(tempDir)
-
-	classes, err := project.Classes()
-
-	assert.Nil(t, classes)
-	assert.Error(t, err)
-}
-
 func TestFilesystemProject_Classes_ErrorDuringTraversal(t *testing.T) {
 	SkipOnWindows(t)
 	tempDir := t.TempDir()
@@ -89,25 +74,18 @@ func TestFilesystemProject_Classes_ErrorDuringTraversal(t *testing.T) {
 }
 
 func TestFilesystemClass_Name(t *testing.T) {
-	class := &FilesystemClass{name: "TestClass"}
+	class := &FSClass{name: "TestClass"}
 
 	assert.Equal(t, "TestClass", class.Name())
-}
-
-func TestFilesystemClass_Content(t *testing.T) {
-	class := &FilesystemClass{content: "class TestClass {}"}
-
-	assert.Equal(t, "class TestClass {}", class.Content())
 }
 
 func TestFilesystemClass_SetContent_Success(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "TestClass.java")
 	require.NoError(t, os.WriteFile(filePath, []byte("class TestClass {}"), 0o600))
-	class := &FilesystemClass{
-		name:    "TestClass",
-		content: "class TestClass {}",
-		path:    filePath,
+	class := &FSClass{
+		name: "TestClass",
+		path: filePath,
 	}
 	newContent := "class UpdatedClass {}"
 

--- a/internal/domain/in_mem_project.go
+++ b/internal/domain/in_mem_project.go
@@ -10,16 +10,9 @@ type InMemoryProject struct {
 	files map[string]Class
 }
 
-// InMemoryJavaClass is an implementation of JavaClass that stores its data in memory.
-type InMemoryJavaClass struct {
-	name    string
-	content string
-}
-
 // NewMock creates a mock project with predefined content for testing purposes.
 func NewMock() Project {
-	class := NewClass("Main.java", ".", "public class Main {\n\tpublic static void main(String[] args) {\n\t\tString m = \"Hello, World\";\n\t\tSystem.out.println(m);\n\t}\n}\n")
-	return NewInMemory(class)
+	return NewInMemory(NewInMemoryClass("Main.java", ".", "public class Main {\n\tpublic static void main(String[] args) {\n\t\tString m = \"Hello, World\";\n\t\tSystem.out.println(m);\n\t}\n}\n"))
 }
 
 // NewInMemory creates a new in-memory project with the given map of file names to Java class content.
@@ -40,22 +33,6 @@ func (i *InMemoryProject) Classes() ([]Class, error) {
 		res = append(res, class)
 	}
 	return res, nil
-}
-
-// SetContent updates the content of the in-memory Java class.
-func (i *InMemoryJavaClass) SetContent(content string) error {
-	i.content = content
-	return nil
-}
-
-// Content retrieves the content of the in-memory Java class.
-func (i *InMemoryJavaClass) Content() string {
-	return i.content
-}
-
-// Name retrieves the name of the in-memory Java class.
-func (i *InMemoryJavaClass) Name() string {
-	return i.name
 }
 
 // String returns a string representation of the in-memory project.

--- a/internal/domain/mirror_project.go
+++ b/internal/domain/mirror_project.go
@@ -12,7 +12,7 @@ type MirrorProject struct {
 }
 
 // NewMirrorProject creates a mirror of the original FilesystemProject at the given path.
-func NewMirrorProject(original *FilesystemProject, mirrorPath string) (*MirrorProject, error) {
+func NewMirrorProject(original *FSProj, mirrorPath string) (*MirrorProject, error) {
 	if err := os.RemoveAll(filepath.Clean(mirrorPath)); err != nil {
 		return nil, fmt.Errorf("failed to remove existing mirror path: %w", err)
 	}

--- a/internal/domain/suggestion.go
+++ b/internal/domain/suggestion.go
@@ -1,22 +1,29 @@
 package domain
 
-// Suggestion represents a proposed improvement or fix for a class.
-type Suggestion interface {
+// OldSuggestion represents a proposed improvement or fix for a class.
+type OldSuggestion interface {
 	Text() string
 }
 
-type suggestion struct {
+type oldSuggestion struct {
 	text string
 }
 
-// NewSuggestion creates a new Suggestion instance with the given text.
-func NewSuggestion(text string) Suggestion {
-	return &suggestion{
+// NewOldSuggestion creates a new Suggestion instance with the given text.
+func NewOldSuggestion(text string) OldSuggestion {
+	return &oldSuggestion{
 		text: text,
 	}
 }
 
+func NewSuggestion(text, path string) *Suggestion {
+	return &Suggestion{
+		Text:      text,
+		ClassPath: path,
+	}
+}
+
 // Text implements Suggestion.
-func (a *suggestion) Text() string {
+func (a *oldSuggestion) Text() string {
 	return a.text
 }

--- a/internal/fixer/server.go
+++ b/internal/fixer/server.go
@@ -137,7 +137,7 @@ func (f *Fixer) thinkLong(m *protocol.Message) (*protocol.Message, error) {
 		example = job.Examples[0].Content()
 	}
 	for _, suggestion := range job.Suggestions {
-		suggestions = append(suggestions, suggestion.Text())
+		suggestions = append(suggestions, suggestion.Text)
 	}
 	f.log.Info("trying to fix %q class...", class)
 	all := strings.Join(suggestions, "\n")
@@ -157,7 +157,7 @@ func (f *Fixer) thinkLong(m *protocol.Message) (*protocol.Message, error) {
 			Text: fmt.Sprintf("Fix for class %s", class),
 		},
 		Classes: []domain.Class{
-			domain.NewClass(class, path, clean(answer)),
+			domain.NewInMemoryClass(class, path, clean(answer)),
 		},
 	}
 	return res.Marshal().Message, nil

--- a/internal/reviewer/server.go
+++ b/internal/reviewer/server.go
@@ -103,7 +103,7 @@ func (r *A2AReviewer) thinkLong(_ *protocol.Message) (*protocol.Message, error) 
 
 func logSuggestions(logger log.Logger, suggestions []domain.Suggestion) {
 	for i, suggestion := range suggestions {
-		logger.Info("suggestion #%d: %s", i+1, suggestion)
+		logger.Info("#%d: %s", i+1, suggestion.String())
 	}
 }
 


### PR DESCRIPTION
In this PR I've enxtended the 'Suggestion' structure with the class reference (a relative project class path). Now it's much easy for an agent to unserstand dependenceis between classess and concrete suggestions.

Related to #82