### PR TITLE
refactor(#108): consolidate prompts into `internal/prompts` directory with `.md.templ` extension

### DIFF
--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -15,12 +15,12 @@ const openai = "openai"
 const mock = "mock"
 
 // New creates a new instance of Brain based on the provided provider and optional playbook strings.
-func New(provider, token string, playbook ...string) (Brain, error) {
+func New(provider, token, system string, playbook ...string) (Brain, error) {
 	switch provider {
 	case deepseek:
-		return NewDeepSeek(token), nil
+		return NewDeepSeek(token, system), nil
 	case openai:
-		return NewOpenAI(token), nil
+		return NewOpenAI(token, system), nil
 	case mock:
 		if len(playbook) == 0 {
 			return NewMock(), nil

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const system = "system prompt"
+
 func TestNew_WithDeepSeekProvider_ReturnsDeepSeekBrain(t *testing.T) {
 	token := "valid_token"
 
-	result, err := New(deepseek, token)
+	result, err := New(deepseek, token, system)
 
 	require.NoError(t, err, "Expected no error when creating DeepSeek brain")
 	_, ok := result.(*deepSeek)
@@ -20,7 +22,7 @@ func TestNew_WithDeepSeekProvider_ReturnsDeepSeekBrain(t *testing.T) {
 func TestNew_WithOpenAIProvider_ReturnsOpenAIBrain(t *testing.T) {
 	token := "valid_openai_token"
 
-	result, err := New(openai, token)
+	result, err := New(openai, token, system)
 
 	require.NoError(t, err, "Expected no error when creating OpenAI brain")
 	_, ok := result.(*openAI)
@@ -28,7 +30,7 @@ func TestNew_WithOpenAIProvider_ReturnsOpenAIBrain(t *testing.T) {
 }
 
 func TestNew_MockProviderNoPlaybook_ReturnsMockInstance(t *testing.T) {
-	result, err := New(mock, "test-token")
+	result, err := New(mock, "test-token", system)
 
 	require.NoError(t, err)
 	_, ok := result.(*mockBrain)
@@ -36,7 +38,7 @@ func TestNew_MockProviderNoPlaybook_ReturnsMockInstance(t *testing.T) {
 }
 
 func TestNew_UnknownProvider_ReturnsError(t *testing.T) {
-	b, err := New("unknown", "test-token")
+	b, err := New("unknown", "test-token", system)
 
 	require.Error(t, err)
 	assert.Nil(t, b)

--- a/internal/brain/deepseek.go
+++ b/internal/brain/deepseek.go
@@ -13,9 +13,10 @@ import (
 
 // deepSeek represents a client for interacting with the deepSeek API.
 type deepSeek struct {
-	token string
-	url   string
-	model string
+	token  string
+	url    string
+	model  string
+	system string
 }
 
 type deepseekReq struct {
@@ -39,7 +40,7 @@ type deepseekMsg struct {
 }
 
 // NewDeepSeek creates a new deepSeek instance with the provided API key.
-func NewDeepSeek(apiKey string) Brain {
+func NewDeepSeek(apiKey, system string) Brain {
 	return &deepSeek{
 		token: apiKey,
 		url:   "https://api.deepseek.com/chat/completions",
@@ -50,7 +51,7 @@ func NewDeepSeek(apiKey string) Brain {
 // Ask sends a question to the deepSeek API and retrieves an answer.
 func (d *deepSeek) Ask(question string) (string, error) {
 	log.Debug("deepSeek: asking question: %s", question)
-	return d.send("You are a helpful assistant.", question)
+	return d.send(d.system, question)
 }
 
 func (d *deepSeek) send(system, user string) (answer string, err error) {

--- a/internal/brain/deepseek_test.go
+++ b/internal/brain/deepseek_test.go
@@ -11,7 +11,7 @@ func TestDeepSeek_Ask_PositiveCase(t *testing.T) {
 	server := NewEchoServer(t, "deepseek-chat", "test_api_key")
 	defer server.Close()
 
-	deepseek := NewDeepSeek("test_api_key")
+	deepseek := NewDeepSeek("test_api_key", "sysprompt")
 	deepseek.(*deepSeek).url = server.URL
 
 	answer, err := deepseek.Ask("This is a test question")
@@ -23,7 +23,7 @@ func TestDeepSeek_Ask_NegativeCase(t *testing.T) {
 	server := NewErrorServer(t)
 	defer server.Close()
 
-	deepseek := NewDeepSeek("test_api_key")
+	deepseek := NewDeepSeek("test_api_key", "deepseek system prompt")
 	deepseek.(*deepSeek).url = server.URL
 
 	answer, err := deepseek.Ask("This is a test question")

--- a/internal/brain/openai.go
+++ b/internal/brain/openai.go
@@ -12,9 +12,10 @@ import (
 
 // OpenAI represents a client for interacting with the OpenAI API
 type openAI struct {
-	token string
-	url   string
-	model string
+	token  string
+	url    string
+	model  string
+	system string
 }
 
 type openaiReq struct {
@@ -36,17 +37,18 @@ type openaiMsg struct {
 }
 
 // NewOpenAI creates a new OpenAI instance
-func NewOpenAI(apiKey string) Brain {
+func NewOpenAI(apiKey, system string) Brain {
 	return &openAI{
-		token: apiKey,
-		url:   "https://api.openai.com/v1/chat/completions",
-		model: "gpt-3.5-turbo", // Default model
+		token:  apiKey,
+		url:    "https://api.openai.com/v1/chat/completions",
+		model:  "gpt-3.5-turbo", // Default model
+		system: system,
 	}
 }
 
 // Ask sends a question to the OpenAI API
 func (o *openAI) Ask(question string) (string, error) {
-	return o.send("You are a helpful assistant.", question)
+	return o.send(o.system, question)
 }
 
 func (o *openAI) send(system, user string) (answer string, err error) {

--- a/internal/brain/openai_test.go
+++ b/internal/brain/openai_test.go
@@ -10,7 +10,7 @@ func TestOpenAI_Ask_PositiveCase(t *testing.T) {
 	server := NewEchoServer(t, "gpt-3.5-turbo", "test_api_key")
 	defer server.Close()
 
-	openai := NewOpenAI("test_api_key")
+	openai := NewOpenAI("test_api_key", "openai sys prompt")
 	openai.(*openAI).url = server.URL
 
 	answer, err := openai.Ask("This is a test question")
@@ -23,7 +23,7 @@ func TestOpenAI_Ask_NegativeCase(t *testing.T) {
 	server := NewErrorServer(t)
 	defer server.Close()
 
-	openai := NewOpenAI("test_api_key")
+	openai := NewOpenAI("test_api_key", "openai system prompt")
 	openai.(*openAI).url = server.URL
 
 	answer, err := openai.Ask("This is a test question")

--- a/internal/prompts/critic/critic.md.tmpl
+++ b/internal/prompts/critic/critic.md.tmpl
@@ -1,0 +1,27 @@
+Analyze the following Java code:
+
+{{ .Code }}
+
+Identify issues such as:
+* grammar and spelling mistakes in comments,
+* variables that can be inlined or removed,
+* unnecessary comments inside methods,
+* redundant code.
+
+Do **not** suggest any changes that alter functionality.  
+Do **not** suggest moving code between files (e.g., extract class or interface).  
+Do **not** suggest renaming methods or classes.  
+Do **not** suggest upgrading or replacing libraries.
+
+Consider the following imperfections reported by static analysis:
+{{- if .Defects }}
+{{- range .Defects }}
+- {{ . }}
+{{- end }}
+{{- else }}
+(none)
+{{- end }}
+
+Respond with plain text, one suggestion per line.  
+If there are no significant issues, respond with: {{ .NotFound }}
+

--- a/internal/prompts/facilitator/choose.md.tmpl
+++ b/internal/prompts/facilitator/choose.md.tmpl
@@ -1,0 +1,19 @@
+Given the grouped suggestions below, identify the largest group (the one with the most suggestions).
+Return only the suggestions from that group.
+
+Do **not** include group names, headers, or any explanations.
+Do **not** modify any suggestion; keep class names intact.
+Return suggestions exactly as written.
+
+Suggestions:
+
+{{ .Groupped }}
+
+Answer format (one per line):
+<java class path>: <suggestion 1>
+<java class path>: <suggestion 2>
+<java class path>: <suggestion 3>
+
+Example:
+src/test/java/com/example/service/Example.java: Fix the typo in the class comment
+

--- a/internal/prompts/facilitator/group.md.tmpl
+++ b/internal/prompts/facilitator/group.md.tmpl
@@ -1,0 +1,23 @@
+Here is a list of code improvement suggestions:
+
+{{- range .Suggestions }}
+{{ .ClassPath }}: {{ .Text }}
+{{- end }}
+
+Your task:
+1. Group similar suggestions by topic (e.g., comments, naming, error handling, formatting).
+2. If a group contains multiple similar suggestions, return all suggestions from that group.
+4. Do **not** change the text of any suggestion.
+5. Do **not** explain or comment. Output only the selected suggestions, one per line.
+6. Do **not** remove or modify class names in any suggestion.
+
+Important: Return suggestions exactly as written, without alteration.
+
+Answer in the following format:
+<java class path>: <suggestion 1>
+<java class path>: <suggestion 2>
+<java class path>: <suggestion 3>
+
+Example:
+src/test/java/com/example/service/Example.java: Fix the typo in the class comment
+

--- a/internal/prompts/fixer/fix.md.tmpl
+++ b/internal/prompts/fixer/fix.md.tmpl
@@ -1,0 +1,31 @@
+# Fix Java Class — {{ .FilePath }}
+You are a precise Java code editor. Rewrite the class below by applying the given suggestions.
+
+## Path
+File: {{ .FilePath }}
+
+## Original Code
+
+```
+{{ .Code }}
+```
+
+## Suggestions
+{{- range .Suggestions }}
+{{ .ClassPath }}: {{ .Text }}
+{{- end }}
+
+## Rules
+- Return only the final Java source file, nothing else.
+- Output raw Java — **no** markdown fences, **no** diff markers, **no** comments or explanations.
+- Do **not** rename the class. Keep public API names unless a suggestion explicitly requires a change.
+- Do **not** remove JavaDoc comments; you may update them to stay accurate.
+- Preserve the existing package and imports unless a suggestion requires changing them.
+- Ensure the result compiles and includes the entire file content from the package line (if any) to the final }.
+- Do **not** add external dependencies unless explicitly requested by a suggestion.
+
+
+## Final check (silent)
+- No leading/trailing blank lines outside the code.
+- No backtick fences, no “diff” syntax, no headings.
+

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -1,0 +1,48 @@
+package prompts
+
+import (
+	"embed"
+	"strings"
+	"text/template"
+)
+
+//go:embed *.tmpl */*.tmpl
+var files embed.FS
+
+type System struct {
+	AgentName      string
+	ProjectContext string
+	Constraints    []string
+	Capabilities   []string
+}
+
+func (s *System) String() string {
+	tmpl, err := template.ParseFS(files, "system.md.tmpl")
+	if err != nil {
+		panic(err)
+	}
+	var result strings.Builder
+	err = tmpl.Execute(&result, s)
+	if err != nil {
+		panic(err)
+	}
+	return result.String()
+}
+
+type User struct {
+	Data any
+	Name string
+}
+
+func (u *User) String() string {
+	tmpl, err := template.ParseFS(files, u.Name)
+	if err != nil {
+		panic(err)
+	}
+	var result strings.Builder
+	err = tmpl.Execute(&result, u.Data)
+	if err != nil {
+		panic(err)
+	}
+	return result.String()
+}

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -1,0 +1,70 @@
+package prompts
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const system = `# System Prompt for TestAgent
+
+You are a non-chatty tool that works with **Java code**. Respond with the **required output only**, no preface, no explanations, no headings, no extra lines.
+
+## Context
+TestProject
+
+## Constraints
+- None
+
+## Defaults
+- Null verbosity: Do not include rationale or commentary.
+
+## Capabilities
+- Basic
+
+## Final Check (silent)
+- No explanations, no markdown fences.
+`
+
+const user = "# User Prompt for UserAgent\n"
+
+func TestSystem_String_WithValidTemplate(t *testing.T) {
+	s := System{
+		AgentName:      "TestAgent",
+		ProjectContext: "TestProject",
+		Constraints:    []string{"None"},
+		Capabilities:   []string{"Basic"},
+	}
+
+	res := s.String()
+
+	require.NotNil(t, res)
+	require.Equal(t, system, strings.ReplaceAll(res, "\r", ""))
+}
+
+func TestUser_String_WithValidTemplate(t *testing.T) {
+	u := User{
+		Data: map[string]any{
+			"AgentName": "UserAgent",
+		},
+		Name: "test.md.tmpl",
+	}
+
+	res := u.String()
+
+	require.NotNil(t, res)
+	require.Equal(t, user, strings.ReplaceAll(res, "\r", ""))
+}
+
+func TestUser_String_FromAnotherFolder(t *testing.T) {
+	u := User{
+		Data: map[string]any{},
+		Name: "critic/critic.md.tmpl",
+	}
+
+	res := u.String()
+
+	require.NotNil(t, res)
+	require.Contains(t, res, "Analyze the following Java code")
+}

--- a/internal/prompts/reviewer/review.md.tmpl
+++ b/internal/prompts/reviewer/review.md.tmpl
@@ -1,0 +1,34 @@
+You are an experienced software engineer. The following command failed during compilation or build:
+
+Command: {{ .Command }}
+Working directory: {{ .WorkDir }}
+Error: {{ .Error }}
+
+{{- if .Stderr }}
+--- STDERR ---
+{{ .Stderr }}
+______________
+{{- end }}
+
+{{- if .Stdout }}
+--- STDOUT ---
+{{ .Stdout }}
+______________
+{{- end }}
+
+Please suggest specific, actionable steps to fix the problem.
+- Focus only on the issues visible in the provided output.
+- Keep the suggestions short and practical.
+- If there are multiple possible causes, list them in priority order.
+- Do not suggest general fixes or unrelated changes.
+- Do not suggest new libraries or tools.
+- Use single-line suggestions, each starting with a class name followed by a colon and the suggestion text.
+
+Answer in the following format:
+	<java class path>: <suggestion 1>
+	<java class path>: <suggestion 2>
+	<java class path>: <suggestion 3>
+
+Example:
+	src/test/java/com/example/service/Example.java: Fix the typo in the class comment
+

--- a/internal/prompts/system.md.tmpl
+++ b/internal/prompts/system.md.tmpl
@@ -1,0 +1,28 @@
+# System Prompt for {{ .AgentName }}
+
+You are a non-chatty tool that works with **Java code**. Respond with the **required output only**, no preface, no explanations, no headings, no extra lines.
+{{- if .ProjectContext }}
+
+## Context
+{{ .ProjectContext }}
+{{- end }}
+{{- if .Constraints }}
+
+## Constraints
+{{- range .Constraints }}
+- {{ . }}
+{{- end }}
+{{- end }}
+
+## Defaults
+- Null verbosity: Do not include rationale or commentary.
+{{- if .Capabilities }}
+
+## Capabilities
+{{- range .Capabilities }}
+- {{ . }}
+{{- end }}
+{{- end }}
+
+## Final Check (silent)
+- No explanations, no markdown fences.

--- a/internal/prompts/test.md.tmpl
+++ b/internal/prompts/test.md.tmpl
@@ -1,0 +1,1 @@
+# User Prompt for {{ .AgentName }}


### PR DESCRIPTION
This PR refactors prompts into the `internal/prompts` directory, ensuring all prompts have a `.md.templ` extension for better organization and reuse.

Fixes #108