### PR TITLE
feat(#110): make reviewer agent commands configurable via CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ Or, if you are already in the `refrax` folder, simply run:
 refrax refactor --output="./out" --ai=deepseek test/test_data/java/person
 ```
 
+### Checking Results
+
+`refrax` does not inherently verify whether the applied changes are correct or cause any issues. 
+To address this, you can use the `--check` option to validate the changes. Multiple `--check` options can be provided, as shown below:
+
+```sh
+refrax refactor . --ai=deepseek --check="mvn clean test" --check="mvn qulice:check -Pqulice"
+```
+
+When at least one `--check` option is specified, the `reviewer` agent executes the provided checks and delivers feedback to the `facilitator` agent.
+
 ## Configuration
 
 - `--ai, -a`: Specify the AI provider (e.g., deepseek, openai).

--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -9,6 +9,7 @@ import (
 func newRefactorCmd(params *client.Params) *cobra.Command {
 	var output string
 	var maxSize int
+	var checks []string
 	command := &cobra.Command{
 		Use:     "refactor [path]",
 		Short:   "refactor code in the given directory (defaults to current)",
@@ -22,11 +23,13 @@ func newRefactorCmd(params *client.Params) *cobra.Command {
 			params.Input = path
 			params.Output = output
 			params.MaxSize = maxSize
+			params.Checks = checks
 			_, err := client.Refactor(params)
 			return err
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "", "output path for the refactored code")
 	command.Flags().IntVar(&maxSize, "max-size", 200, "maximum number of changes allowed in a single refactoring cycle")
+	command.Flags().StringSliceVar(&checks, "check", make([]string, 0), "check commands to run after refactoring")
 	return command
 }

--- a/internal/client/params.go
+++ b/internal/client/params.go
@@ -17,6 +17,7 @@ type Params struct {
 	Output      string
 	MaxSize     int
 	Log         io.Writer
+	Checks      []string
 }
 
 // NewMockParams creates a new Params object with mock settings.
@@ -34,5 +35,6 @@ func NewMockParams() *Params {
 		Output:      "",
 		MaxSize:     200,
 		Log:         io.Discard, // Default to discard if no logging is needed
+		Checks:      []string{"mvn clean test"},
 	}
 }

--- a/internal/client/refrax_client.go
+++ b/internal/client/refrax_client.go
@@ -131,7 +131,7 @@ func (c *RefraxClient) Refactor(proj domain.Project) (domain.Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port for reviewer: %w", err)
 	}
-	rvwr := reviewer.NewReviewer(reviewerBrain, reviewerPort, "mvn clean test", "mvn qulice:check -Pqulice")
+	rvwr := reviewer.NewReviewer(reviewerBrain, reviewerPort, c.params.Checks...)
 	rvwr.Handler(countStats(reviewerStats))
 
 	facilitatorStats := &stats.Stats{Name: "facilitator"}

--- a/internal/reviewer/agent.go
+++ b/internal/reviewer/agent.go
@@ -30,6 +30,7 @@ type promptData struct {
 
 func (a *agent) Review() (*domain.Artifacts, error) {
 	var res []domain.Suggestion
+	a.logger.Info("starting review using %d commands, %s", len(a.cmds), strings.Join(a.cmds, ", "))
 	for _, cmd := range a.cmds {
 		suggestions, err := a.runCmd(cmd)
 		if err != nil {


### PR DESCRIPTION
This PR makes the `reviewer` agent commands configurable via CLI options, allowing users to specify checks for each `refrax` run.

Fixes #110