### PR TITLE
style(#113): remove meaningless package comments

### DIFF
--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -1,4 +1,3 @@
-// Package brain provides an interface and implementations for asking questions programmatically.
 package brain
 
 import "fmt"

--- a/internal/client/params.go
+++ b/internal/client/params.go
@@ -1,4 +1,3 @@
-// Package client provides functionality for client-side operations.
 package client
 
 import "io"

--- a/internal/critic/server.go
+++ b/internal/critic/server.go
@@ -1,4 +1,3 @@
-// Package critic provides functionality for analyzing and critiquing Java code.
 package critic
 
 import (

--- a/internal/domain/a2a.go
+++ b/internal/domain/a2a.go
@@ -1,4 +1,3 @@
-// Package domain is for the domain.
 package domain
 
 import (

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,4 +1,3 @@
-// Package env provides utilities for environment variable management.
 package env
 
 import (

--- a/internal/facilitator/server.go
+++ b/internal/facilitator/server.go
@@ -1,4 +1,3 @@
-// Package facilitator is for the facilitator.
 package facilitator
 
 import (

--- a/internal/fixer/server.go
+++ b/internal/fixer/server.go
@@ -1,4 +1,3 @@
-// Package fixer is for the fixer.
 package fixer
 
 import (

--- a/internal/protocol/a2a_server.go
+++ b/internal/protocol/a2a_server.go
@@ -153,11 +153,11 @@ func basic(ctx context.Context, mh MsgHandler) Handler {
 			resp := success(id, msg)
 			return &resp, nil
 		case "message/stream":
-			panic("Message/stream is not implemented yet")
+			panic("message/stream is not implemented yet")
 		case "tasks/get":
-			panic("Tasks/get is not implemented yet")
+			panic("tasks/get is not implemented yet")
 		case "tasks/cancel":
-			panic("Tasks/get is not implemented yet")
+			panic("tasks/get is not implemented yet")
 		default:
 			resp := failure(id, ErrCodeMethodNotFound, "Method not found")
 			return &resp, nil

--- a/internal/reviewer/agent.go
+++ b/internal/reviewer/agent.go
@@ -1,4 +1,3 @@
-// Package reviewer is for the reviewer.
 package reviewer
 
 import (

--- a/internal/stats/csv_writer.go
+++ b/internal/stats/csv_writer.go
@@ -1,4 +1,3 @@
-// Package stats provides functionality to write statistics.
 package stats
 
 import (

--- a/internal/tool/aibolit.go
+++ b/internal/tool/aibolit.go
@@ -1,4 +1,3 @@
-// Package tool provides tools for identifying refactoring opportunities in code.
 package tool
 
 import (

--- a/internal/util/base64.go
+++ b/internal/util/base64.go
@@ -1,4 +1,3 @@
-// Package util provides utility functions for various operations.
 package util
 
 import (


### PR DESCRIPTION
This PR remove meaningless package comments.

Also, I fixed a few 'panic' messages:

```
		case "message/stream":
			panic("message/stream is not implemented yet")
		case "tasks/get":
			panic("tasks/get is not implemented yet")
		case "tasks/cancel":
			panic("tasks/get is not implemented yet")
```

The `message/stream` is an id, not arbitrary text.

Related to #113