### PR TITLE
fix(#115): handle token retrieval error to prevent nil pointer dereference

### DIFF
--- a/internal/client/refrax_client_test.go
+++ b/internal/client/refrax_client_test.go
@@ -8,7 +8,17 @@ import (
 
 	"github.com/cqfn/refrax/internal/domain"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestTokenNotFound(t *testing.T) {
+	params := NewMockParams()
+	params.Token = ""
+	client := NewRefraxClient(params)
+	_, err := client.Refactor(domain.NewMock())
+	require.Error(t, err)
+	require.Equal(t, "failed to find token: token not found, please provide it via --token flag or in .env file", err.Error())
+}
 
 func TestRefraxClient_Creates_Successfully(t *testing.T) {
 	client := NewRefraxClient(NewMockParams())

--- a/internal/critic/server.go
+++ b/internal/critic/server.go
@@ -93,6 +93,9 @@ func (c *Critic) thinkLong(m *protocol.Message) (*protocol.Message, error) {
 		return nil, fmt.Errorf("failed to parse task from message: %w", err)
 	}
 	artifacts, err := c.agent.Review(tsk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to review the task: %w", err)
+	}
 	return artifacts.Marshal().Message, err
 }
 


### PR DESCRIPTION
This PR fixes a `nil pointer dereference` issue in the `RefraxClient` by ensuring a valid token is provided before processing requests.

Related to #115