### PR TITLE
fix(#120): use OPENAI_API_KEY instead of OPENAI_TOKEN in env variables

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -12,9 +12,9 @@ import (
 func Token(path, provider string) string {
 	switch provider {
 	case "deepseek":
-		return find(path, "DEEPSEEK_TOKEN")
+		return find(path, "DEEPSEEK_API_KEY")
 	case "openai":
-		return find(path, "OPENAI_TOKEN")
+		return find(path, "OPENAI_API_KEY")
 	case "mock":
 		return find(path, "MOCK_TOKEN")
 	default:

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -67,7 +67,7 @@ func TestProviderToken_DeepseekTokenPresent(t *testing.T) {
 	tmp := t.TempDir()
 	deepseek := "deepseek-token-value"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s", deepseek), 0o600)
+	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_API_KEY=%s", deepseek), 0o600)
 	require.NoError(t, err)
 
 	result := Token(env, "deepseek")
@@ -79,7 +79,7 @@ func TestProviderToken_OpenAITokenPresent(t *testing.T) {
 	tmp := t.TempDir()
 	openai := "openai-token-value"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "OPENAI_TOKEN=%s", openai), 0o600)
+	err := os.WriteFile(env, fmt.Appendf(nil, "OPENAI_API_KEY=%s", openai), 0o600)
 	require.NoError(t, err)
 
 	result := Token(env, "openai")
@@ -124,7 +124,7 @@ func TestProviderToken_DefaultTokenIgnoredWhenDeepseekTokenExists(t *testing.T) 
 	deepseek := "deepseek-token-val"
 	token := "default-ignored-deepseek-token-val"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s\nTOKEN=%s\n", deepseek, token), 0o600)
+	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_API_KEY=%s\nTOKEN=%s\n", deepseek, token), 0o600)
 	require.NoError(t, err)
 
 	result := Token(env, "deepseek")
@@ -137,7 +137,7 @@ func TestProviderToken_DefaultTokenIgnoredWhenOpenAITokenExists(t *testing.T) {
 	openai := "openai-token-val"
 	token := "default-openai-token-val"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "OPENAI_TOKEN=%s\nTOKEN=%s\n", openai, token), 0o600)
+	err := os.WriteFile(env, fmt.Appendf(nil, "OPENAI_API_KEY=%s\nTOKEN=%s\n", openai, token), 0o600)
 	require.NoError(t, err)
 
 	result := Token(env, "openai")
@@ -150,7 +150,7 @@ func TestProviderToken_DefaultTokenUsedWhenDeepseekNotRequested(t *testing.T) {
 	deepseek := "deepseek-token"
 	token := "default-used-deepseek-token"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_TOKEN=%s\nTOKEN=%s\n", deepseek, token), 0o600)
+	err := os.WriteFile(env, fmt.Appendf(nil, "DEEPSEEK_API_KEY=%s\nTOKEN=%s\n", deepseek, token), 0o600)
 	require.NoError(t, err)
 
 	result := Token(env, "otherprovider")
@@ -163,7 +163,7 @@ func TestProviderToken_DefaultTokenUsedWhenOpenAINotRequested(t *testing.T) {
 	openai := "openai-token"
 	token := "default-openai-token"
 	env := filepath.Join(tmp, ".env")
-	err := os.WriteFile(env, fmt.Appendf(nil, "OPENAI_TOKEN=%s\nTOKEN=%s\n", openai, token), 0o600)
+	err := os.WriteFile(env, fmt.Appendf(nil, "OPENAI_API_KEY=%s\nTOKEN=%s\n", openai, token), 0o600)
 	require.NoError(t, err)
 
 	result := Token(env, "otherprovider")


### PR DESCRIPTION
This PR updates environment variable references from `*_TOKEN` to `*_API_KEY` for consistency with common practices.

Related to #120