### PR TITLE
feat(#119): add support for `refrax --version` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out/
 refrax
 tmp-copy/
 tmp/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,11 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - -s -w
+      - -X github.com/cqfn/refrax/internal/util.version={{.Version}}
+      - -X github.com/cqfn/refrax/internal/util.commit={{.FullCommit}}
+      - -X github.com/cqfn/refrax/internal/util.datetime={{.Date}}
 
 archives:
   - formats: [tar.gz]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/cqfn/refrax/internal/client"
+	"github.com/cqfn/refrax/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -39,5 +40,7 @@ func NewRootCmd(out, _ io.Writer) *cobra.Command {
 		newRefactorCmd(&params),
 		newStartCmd(),
 	)
+	root.Version = util.Version()
+	root.SetVersionTemplate("refrax {{.Version}}\n")
 	return root
 }

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/cqfn/refrax
 
 go 1.24.2
 
-require github.com/spf13/cobra v1.9.1
+require (
+	github.com/google/uuid v1.3.0
+	github.com/spf13/cobra v1.9.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/internal/util/version.go
+++ b/internal/util/version.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"strings"
+)
+
+const (
+	defaultVersion  = "dev"
+	defaultCommit   = "none"
+	defaultDatetime = "none"
+)
+
+var (
+	// Use the following command to change this value:
+	// go build -ldflags "-X github.com/cqfn/refrax/internal/util.version=<version>"
+	version string = defaultVersion
+
+	// Use the following command to change this value:
+	// go build -ldflags "-X github.com/cqfn/refrax/internal/util.commit=<commit-hash>"
+	commit string = defaultCommit
+
+	// Use the following command to change this value:
+	// go build -ldflags "-X github.com/cqfn/refrax/internal/util.datetime=<date-time>"
+	datetime string = defaultDatetime
+)
+
+func Version() string {
+	parts := []string{version}
+	if commit != defaultCommit {
+		parts = append(parts, "commit", commit)
+	}
+	if datetime != defaultDatetime {
+		parts = append(parts, "built at", datetime)
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/util/version_test.go
+++ b/internal/util/version_test.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentVersion(t *testing.T) {
+	datetime = "2024-01-01T00:00:00Z"
+	assert.Equal(t, "dev built at "+datetime, Version())
+}


### PR DESCRIPTION
This PR implements support for the `refrax --version` command to display the current version of the application.

Related to #119