### PR TITLE
feat(#125): add --no-colors option to disable colored output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ func NewRootCmd(out, _ io.Writer) *cobra.Command {
 	root.PersistentFlags().BoolVar(&params.Stats, "stats", false, "Print internal interaction statistics")
 	root.PersistentFlags().StringVar(&params.Format, "stats-format", "std", "Format for statistics output (std, csv)")
 	root.PersistentFlags().StringVar(&params.Soutput, "stats-output", "stats", "Output path for statistics")
+	root.PersistentFlags().BoolVar(&params.Colorless, "no-colors", false, "Disable colored output")
 	root.AddCommand(
 		newRefactorCmd(&params),
 		newStartCmd(),

--- a/internal/client/params.go
+++ b/internal/client/params.go
@@ -17,6 +17,7 @@ type Params struct {
 	MaxSize     int
 	Log         io.Writer
 	Checks      []string
+	Colorless   bool
 }
 
 // NewMockParams creates a new Params object with mock settings.
@@ -33,7 +34,8 @@ func NewMockParams() *Params {
 		Input:       "",
 		Output:      "",
 		MaxSize:     200,
-		Log:         io.Discard, // Default to discard if no logging is needed
+		Log:         io.Discard,
 		Checks:      []string{"mvn clean test"},
+		Colorless:   false,
 	}
 }

--- a/internal/client/refrax_client.go
+++ b/internal/client/refrax_client.go
@@ -84,7 +84,7 @@ func (c *RefraxClient) Refactor(proj domain.Project) (domain.Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port for critic: %w", err)
 	}
-	ctc := critic.NewCritic(criticBrain, criticPort)
+	ctc := critic.NewCritic(criticBrain, criticPort, c.params.Colorless)
 	ctc.Handler(countStats(criticStats))
 
 	fixerStats := &stats.Stats{Name: "fixer"}
@@ -110,7 +110,7 @@ func (c *RefraxClient) Refactor(proj domain.Project) (domain.Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port for fixer: %w", err)
 	}
-	fxr := fixer.NewFixer(fixerBrain, fixerPort)
+	fxr := fixer.NewFixer(fixerBrain, fixerPort, c.params.Colorless)
 	fxr.Handler(countStats(fixerStats))
 
 	reviewerStats := &stats.Stats{Name: "reviewer"}
@@ -135,7 +135,7 @@ func (c *RefraxClient) Refactor(proj domain.Project) (domain.Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port for reviewer: %w", err)
 	}
-	rvwr := reviewer.NewReviewer(reviewerBrain, reviewerPort, c.params.Checks...)
+	rvwr := reviewer.NewReviewer(reviewerBrain, reviewerPort, c.params.Colorless, c.params.Checks...)
 	rvwr.Handler(countStats(reviewerStats))
 
 	facilitatorStats := &stats.Stats{Name: "facilitator"}
@@ -158,7 +158,7 @@ func (c *RefraxClient) Refactor(proj domain.Project) (domain.Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port for facilitator: %w", err)
 	}
-	fclttor := facilitator.NewFacilitator(facilitatorBrain, ctc, fxr, rvwr, facilitatorPort)
+	fclttor := facilitator.NewFacilitator(facilitatorBrain, ctc, fxr, rvwr, facilitatorPort, c.params.Colorless)
 	fclttor.Handler(countStats(facilitatorStats))
 
 	go func() {
@@ -269,9 +269,9 @@ func shutdown(s shudownable) {
 
 func initLogger(params *Params) {
 	if params.Debug {
-		log.Set(log.NewZerolog(params.Log, "debug"))
+		log.Set(log.NewZerolog(params.Log, "debug", params.Colorless))
 	} else {
-		log.Set(log.NewZerolog(params.Log, "info"))
+		log.Set(log.NewZerolog(params.Log, "info", params.Colorless))
 	}
 }
 

--- a/internal/critic/server.go
+++ b/internal/critic/server.go
@@ -21,8 +21,8 @@ type Critic struct {
 }
 
 // NewCritic creates and initializes a new instance of Critic.
-func NewCritic(ai brain.Brain, port int, tools ...tool.Tool) *Critic {
-	logger := log.NewPrefixed("critic", log.NewColored(log.Default(), log.Cyan))
+func NewCritic(ai brain.Brain, port int, colorless bool, tools ...tool.Tool) *Critic {
+	logger := log.New("critic", log.Cyan, colorless)
 	server := protocol.NewServer(agentCard(port), port)
 	critic := &Critic{
 		server: server,

--- a/internal/critic/server_test.go
+++ b/internal/critic/server_test.go
@@ -59,7 +59,7 @@ type MockBrain struct{}
 func TestNewCritic_Success(t *testing.T) {
 	ai := brain.NewMock()
 
-	critic := NewCritic(ai, 18081)
+	critic := NewCritic(ai, 18081, false)
 	require.NotNil(t, critic)
 	assert.Equal(t, ai, critic.agent.brain)
 }
@@ -68,7 +68,7 @@ func TestCriticStart_Success(t *testing.T) {
 	ai := brain.NewMock()
 	port, err := util.FreePort()
 	require.NoError(t, err)
-	critic := NewCritic(ai, port)
+	critic := NewCritic(ai, port, false)
 	var listen error
 	var shutdown error
 
@@ -83,7 +83,7 @@ func TestCriticStart_Success(t *testing.T) {
 
 func TestCriticStart_ServerStartError(t *testing.T) {
 	ai := brain.NewMock()
-	critic := NewCritic(ai, 18081)
+	critic := NewCritic(ai, 18081, false)
 	critic.server = &mock{started: true}
 
 	err := critic.ListenAndServe()
@@ -95,7 +95,7 @@ func TestCriticStart_ServerStartError(t *testing.T) {
 func TestCriticClose_Success(t *testing.T) {
 	ai := brain.NewMock()
 	server := &mock{started: true}
-	critic := NewCritic(ai, 18081)
+	critic := NewCritic(ai, 18081, false)
 	critic.server = server
 
 	err := critic.Shutdown()
@@ -107,7 +107,7 @@ func TestCriticClose_Success(t *testing.T) {
 func TestCriticClose_ServerNotStartedError(t *testing.T) {
 	ai := brain.NewMock()
 	server := &mock{}
-	critic := NewCritic(ai, 18081, tool.NewEmpty())
+	critic := NewCritic(ai, 18081, false, tool.NewEmpty())
 	critic.server = server
 
 	err := critic.Shutdown()
@@ -119,7 +119,7 @@ func TestCriticClose_ServerNotStartedError(t *testing.T) {
 func TestCriticThink_ReturnsMessage(t *testing.T) {
 	ai := brain.NewMock()
 	server := &mock{}
-	critic := NewCritic(ai, 18081, tool.NewEmpty())
+	critic := NewCritic(ai, 18081, false, tool.NewEmpty())
 	critic.server = server
 	msg := protocol.NewMessage().
 		WithMessageID("msg-123").

--- a/internal/facilitator/server.go
+++ b/internal/facilitator/server.go
@@ -20,8 +20,8 @@ type A2AFacilitator struct {
 }
 
 // NewFacilitator creates a new instance of Facilitator to manage communication between agents.
-func NewFacilitator(ai brain.Brain, critic domain.Critic, fixer domain.Fixer, reviewer domain.Reviewer, port int) *A2AFacilitator {
-	logger := log.NewPrefixed("facilitator", log.NewColored(log.Default(), log.Yellow))
+func NewFacilitator(ai brain.Brain, critic domain.Critic, fixer domain.Fixer, reviewer domain.Reviewer, port int, colorless bool) *A2AFacilitator {
+	logger := log.New("facilitator", log.Yellow, colorless)
 	logger.Debug("preparing server on port %d with ai provider %s", port, ai)
 	server := protocol.NewServer(agentCard(port), port)
 	facilitator := &A2AFacilitator{

--- a/internal/fixer/server.go
+++ b/internal/fixer/server.go
@@ -29,8 +29,8 @@ type promptData struct {
 }
 
 // NewFixer creates a new Fixer instance with the provided AI brain and port.
-func NewFixer(ai brain.Brain, port int) *Fixer {
-	logger := log.NewPrefixed("fixer", log.NewColored(log.Default(), log.Magenta))
+func NewFixer(ai brain.Brain, port int, colorless bool) *Fixer {
+	logger := log.New("fixer", log.Magenta, colorless)
 	logger.Debug("preparing server on port %d with ai provider %s", port, ai)
 	server := protocol.NewServer(agentCard(port), port)
 	fixer := &Fixer{

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -11,7 +11,16 @@ type Logger interface {
 	Error(string, ...any)
 }
 
-var single = NewZerolog(os.Stdout, "info")
+var single = NewZerolog(os.Stdout, "info", false)
+
+// Create a new logger with the specified prefix and color settings.
+func New(prefix string, color Color, colorless bool) Logger {
+	if colorless {
+		return NewPrefixed(prefix, Default())
+	} else {
+		return NewPrefixed(prefix, NewColored(Default(), color))
+	}
+}
 
 // Info logs an informational message using the default logger.
 func Info(msg string, args ...any) {

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -89,3 +89,36 @@ func TestLogger_Error(t *testing.T) {
 
 	assert.Contains(t, mock.buf.String(), "ERROR: This is an error message", "Expected error message to be logged")
 }
+
+func TestNew_WithColorlessTrue_ReturnsDefaultLogger(t *testing.T) {
+	p := "colorless-prefix"
+	cl := true
+	c := Red
+
+	l := New(p, c, cl)
+
+	require.NotNil(t, l, "Logger should not be nil")
+	assert.IsType(t, &prefixed{}, l, "Expected a PrefixedLogger")
+	pl, ok := l.(*prefixed)
+	require.True(t, ok, "Logger should be of type *PrefixedLogger")
+	assert.Equal(t, p, pl.prefix, "Prefix should match the input")
+	assert.IsType(t, Default(), pl.original, "Inner logger should be ColoredLogger")
+}
+
+func TestNew_WithColorlessFalse_ReturnsColoredLogger(t *testing.T) {
+	p := "colorfull-prefix"
+	cl := false
+	c := Green
+
+	l := New(p, c, cl)
+
+	require.NotNil(t, l, "Logger should not be nil")
+	assert.IsType(t, &prefixed{}, l, "Expected a PrefixedLogger")
+	pl, ok := l.(*prefixed)
+	require.True(t, ok, "Logger should be of type *PrefixedLogger")
+	assert.Equal(t, p, pl.prefix, "Prefix should match the input")
+	assert.IsType(t, &colored{}, pl.original, "Inner logger should be ColoredLogger")
+	clogger, ok := pl.original.(*colored)
+	require.True(t, ok, "Inner logger should be of type *ColoredLogger")
+	assert.Equal(t, c, clogger.color, "Color should match the input")
+}

--- a/internal/log/zerolog.go
+++ b/internal/log/zerolog.go
@@ -12,13 +12,13 @@ type zero struct {
 
 // NewZerolog creates a new Logger with the specified log level and writer.
 // Details: https://github.com/rs/zerolog
-func NewZerolog(writer io.Writer, level string) Logger {
+func NewZerolog(writer io.Writer, level string, colorless bool) Logger {
 	zlevel, err := zerolog.ParseLevel(level)
 	if err != nil {
 		zlevel = zerolog.InfoLevel
 	}
 	return &zero{
-		logger: zerolog.New(zerolog.ConsoleWriter{Out: writer}).Level(zlevel).With().Timestamp().Logger(),
+		logger: zerolog.New(zerolog.ConsoleWriter{Out: writer, NoColor: colorless}).Level(zlevel).With().Timestamp().Logger(),
 	}
 }
 

--- a/internal/log/zerolog_test.go
+++ b/internal/log/zerolog_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestZerolog_Info(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf, "info")
+	logger := NewZerolog(&buf, "info", false)
 
 	logger.Info("This is an info message")
 
@@ -18,7 +18,7 @@ func TestZerolog_Info(t *testing.T) {
 
 func TestZerolog_Debug(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf, "debug")
+	logger := NewZerolog(&buf, "debug", false)
 
 	logger.Debug("This is a debug message")
 
@@ -27,7 +27,7 @@ func TestZerolog_Debug(t *testing.T) {
 
 func TestZerolog_Warn(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf, "warn")
+	logger := NewZerolog(&buf, "warn", false)
 
 	logger.Warn("This is a warning message")
 
@@ -36,14 +36,14 @@ func TestZerolog_Warn(t *testing.T) {
 
 func TestZerolog_Info_Parametrised(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf, "info")
+	logger := NewZerolog(&buf, "info", false)
 	logger.Info("This is an info message with param: %d", 42)
 	assert.Contains(t, buf.String(), "This is an info message with param: 42", "Expected info message with parameter to be logged")
 }
 
 func TestZerolog_Unknown_UseInfoInstead(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf, "unknown")
+	logger := NewZerolog(&buf, "unknown", false)
 
 	logger.Debug("This is a debug message")
 	logger.Info("This is an info message")
@@ -54,9 +54,18 @@ func TestZerolog_Unknown_UseInfoInstead(t *testing.T) {
 
 func TestZerolog_Error(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf, "error")
+	logger := NewZerolog(&buf, "error", false)
 
 	logger.Error("This is an error message")
 
 	assert.Contains(t, buf.String(), "This is an error message", "Expected error message to be logged")
+}
+
+func TestNoColor(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewZerolog(&buf, "info", true)
+
+	logger.Info("This is an info message")
+
+	assert.NotContains(t, buf.String(), "\x1b[", "Expected no color codes in the log output")
 }

--- a/internal/reviewer/server.go
+++ b/internal/reviewer/server.go
@@ -20,8 +20,8 @@ type A2AReviewer struct {
 }
 
 // NewReviewer creates a new instance of A2AReviewer.
-func NewReviewer(ai brain.Brain, port int, cmds ...string) *A2AReviewer {
-	logger := log.NewPrefixed("reviewer", log.NewColored(log.Default(), log.Orange))
+func NewReviewer(ai brain.Brain, port int, colorless bool, cmds ...string) *A2AReviewer {
+	logger := log.New("reviewer", log.Orange, colorless)
 	logger.Debug("preparing server on port %d", port)
 	server := protocol.NewServer(agentCard(port), port)
 	reviewer := &A2AReviewer{


### PR DESCRIPTION
This PR adds a `--no-colors` option to disable colored output, addressing the issue of color customization in logs.

Related to #125