### PR TITLE
feat(#121): enhance logging and clarify JavaDoc comment guidelines

### DIFF
--- a/internal/facilitator/agent.go
+++ b/internal/facilitator/agent.go
@@ -212,7 +212,7 @@ func (a *agent) repair(refactored []domain.Class) error {
 	suggestions := artifacts.Suggestions
 	a.log.Info("Received %d suggestions from reviewer", len(suggestions))
 	for _, s := range suggestions {
-		a.log.Info("Received suggestion: %s", s)
+		a.log.Info("Received suggestion: %s: %s", s.ClassPath, s.Text)
 	}
 	counter := a.frounds
 	for len(suggestions) > 0 {

--- a/internal/prompts/critic/critic.md.tmpl
+++ b/internal/prompts/critic/critic.md.tmpl
@@ -5,11 +5,12 @@ Analyze the following Java code:
 Identify issues such as:
 * Grammar and spelling mistakes in comments.
 * Variables that can be inlined or removed.
-* Unnecessary comments inside methods.
+* Unnecessary comments inside methods, but not javadocs
 * Redundant code.
 * Long methods.
 * Complex logic that can be simplified.
 
+Do **not** suggest removing JavaDoc comments.
 Do **not** suggest any changes that alter functionality.
 Do **not** suggest moving code between files (e.g., extract class or interface).
 Do **not** suggest renaming methods or classes.

--- a/internal/prompts/facilitator/group.md.tmpl
+++ b/internal/prompts/facilitator/group.md.tmpl
@@ -10,6 +10,7 @@ Your task:
 4. Do **not** change the text of any suggestion.
 5. Do **not** explain or comment. Output only the selected suggestions, one per line.
 6. Do **not** remove or modify class names in any suggestion.
+7. Do **not** suggest removing JavaDoc comments.
 
 Important: Return suggestions exactly as written, without alteration.
 

--- a/internal/prompts/fixer/fix.md.tmpl
+++ b/internal/prompts/fixer/fix.md.tmpl
@@ -20,6 +20,9 @@ File: {{ .FilePath }}
 - Output raw Java — **no** markdown fences, **no** diff markers, **no** comments or explanations.
 - Do **not** rename the class. Keep public API names unless a suggestion explicitly requires a change.
 - Do **not** remove JavaDoc comments; you may update them to stay accurate.
+- Keep JavaDoc comments!
+- Do **not** change functionality unless a suggestion explicitly requires it.
+- Do **not** remove License comments.
 - Preserve the existing package and imports unless a suggestion requires changing them.
 - Ensure the result compiles and includes the entire file content from the package line (if any) to the final }.
 - Do **not** add external dependencies unless explicitly requested by a suggestion.

--- a/internal/prompts/reviewer/review.md.tmpl
+++ b/internal/prompts/reviewer/review.md.tmpl
@@ -22,6 +22,7 @@ Please suggest specific, actionable steps to fix the problem.
 - If there are multiple possible causes, list them in priority order.
 - Do not suggest general fixes or unrelated changes.
 - Do not suggest new libraries or tools.
+- Do not suggesrt removing JavaDoc comments.
 - Use single-line suggestions, each starting with a class name followed by a colon and the suggestion text.
 
 Answer in the following format:


### PR DESCRIPTION
This PR enhances logging and clarifies prompt instructions regarding JavaDoc comments.

Related to #121