### PR TITLE
feat(#132): add attempts parameter to limit LLM processing iterations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func NewRootCmd(out, _ io.Writer) *cobra.Command {
 	root.PersistentFlags().StringVar(&params.Soutput, "stats-output", "stats", "Output path for statistics")
 	root.PersistentFlags().BoolVar(&params.Colorless, "no-colors", false, "Disable colored output")
 	root.PersistentFlags().StringVarP(&params.Model, "model", "m", "", "Model to use (if supported by the AI provider)")
+	root.PersistentFlags().IntVar(&params.Attempts, "attempts", 3, "How many attempts the AI has to make a valid refactoring")
 	root.AddCommand(
 		newRefactorCmd(&params),
 		newStartCmd(),

--- a/internal/client/params.go
+++ b/internal/client/params.go
@@ -19,6 +19,7 @@ type Params struct {
 	Checks      []string
 	Colorless   bool
 	Model       string
+	Attempts    int
 }
 
 // NewMockParams creates a new Params object with mock settings.
@@ -39,5 +40,6 @@ func NewMockParams() *Params {
 		Checks:      []string{"mvn clean test"},
 		Colorless:   false,
 		Model:       "gpt-3.5-turbo",
+		Attempts:    3,
 	}
 }

--- a/internal/client/refrax_client.go
+++ b/internal/client/refrax_client.go
@@ -160,7 +160,7 @@ func (c *RefraxClient) Refactor(proj domain.Project) (domain.Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to find free port for facilitator: %w", err)
 	}
-	fclttor := facilitator.NewFacilitator(facilitatorBrain, ctc, fxr, rvwr, facilitatorPort, c.params.Colorless)
+	fclttor := facilitator.NewFacilitator(facilitatorBrain, ctc, fxr, rvwr, facilitatorPort, c.params.Colorless, c.params.Attempts)
 	fclttor.Handler(countStats(facilitatorStats))
 
 	go func() {

--- a/internal/facilitator/server.go
+++ b/internal/facilitator/server.go
@@ -20,7 +20,7 @@ type A2AFacilitator struct {
 }
 
 // NewFacilitator creates a new instance of Facilitator to manage communication between agents.
-func NewFacilitator(ai brain.Brain, critic domain.Critic, fixer domain.Fixer, reviewer domain.Reviewer, port int, colorless bool) *A2AFacilitator {
+func NewFacilitator(ai brain.Brain, critic domain.Critic, fixer domain.Fixer, reviewer domain.Reviewer, port int, colorless bool, attempts int) *A2AFacilitator {
 	logger := log.New("facilitator", log.Yellow, colorless)
 	logger.Debug("preparing server on port %d with ai provider %s", port, ai)
 	server := protocol.NewServer(agentCard(port), port)
@@ -35,6 +35,7 @@ func NewFacilitator(ai brain.Brain, critic domain.Critic, fixer domain.Fixer, re
 			fixer:    fixer,
 			reviewer: reviewer,
 			frounds:  3,
+			attempts: attempts,
 		},
 	}
 	server.MsgHandler(facilitator.think)


### PR DESCRIPTION
This PR introduces an `attempts` parameter to limit the number of refactoring attempts in `LLM`, preventing infinite loops.

Related to #132