### PR TITLE
feat(#136): add 'custom' provider to connect refrax with custom models

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ func NewRootCmd(out, _ io.Writer) *cobra.Command {
 		PersistentPreRun: func(_ *cobra.Command, _ []string) { params.Log = out },
 	}
 	root.PersistentFlags().StringVarP(&params.Provider, "ai", "a", "none", "AI provider to use (openai, deepseek, none)")
+	root.PersistentFlags().StringVar(&params.ProviderUrl, "ai-url", "", "Custom URL for AI provider")
 	root.PersistentFlags().StringVarP(&params.Token, "token", "t", "", "Token for the AI provider (if required)")
 	root.PersistentFlags().StringVar(&params.Playbook, "playbook", "", "Path to a user-defined YAML playbook for AI integration")
 	root.PersistentFlags().BoolVar(&params.MockProject, "mock-project", false, "Use mock project")

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -15,13 +15,15 @@ const ollama = "ollama"
 
 const mock = "mock"
 
+const custom = "custom"
+
 // New creates a new instance of Brain based on the provided provider and optional playbook strings.
-func New(provider, token, model, system string, playbook ...string) (Brain, error) {
+func New(provider, url, token, model, system string, playbook ...string) (Brain, error) {
 	switch provider {
 	case deepseek:
 		return NewDeepSeek(token, system), nil
 	case openai:
-		return NewOpenAI(token, system), nil
+		return NewOpenAIDefault(token, system)
 	case mock:
 		if len(playbook) == 0 {
 			return NewMock(), nil
@@ -29,6 +31,14 @@ func New(provider, token, model, system string, playbook ...string) (Brain, erro
 		return NewMock(playbook[0]), nil
 	case ollama:
 		return NewOllama("http://localhost:11434", model, token, system), nil
+	case custom:
+		if url == "" {
+			return nil, fmt.Errorf("custom provider requires a URL")
+		}
+		if model == "" {
+			return nil, fmt.Errorf("custom provider requires a model")
+		}
+		return NewCustom(token, url, model, system)
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", provider)
 	}

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -7,12 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const system = "system prompt"
+const (
+	system  = "system prompt"
+	address = "http://custom-provider.com/v1/chat/completions"
+)
 
 func TestNew_WithDeepSeekProvider_ReturnsDeepSeekBrain(t *testing.T) {
 	token := "valid_token"
 
-	result, err := New(deepseek, token, "gemma3", system)
+	result, err := New(deepseek, address, token, "gemma3", system)
 
 	require.NoError(t, err, "Expected no error when creating DeepSeek brain")
 	_, ok := result.(*deepSeek)
@@ -22,7 +25,7 @@ func TestNew_WithDeepSeekProvider_ReturnsDeepSeekBrain(t *testing.T) {
 func TestNew_WithOpenAIProvider_ReturnsOpenAIBrain(t *testing.T) {
 	token := "valid_openai_token"
 
-	result, err := New(openai, token, "llama", system)
+	result, err := New(openai, address, token, "llama", system)
 
 	require.NoError(t, err, "Expected no error when creating OpenAI brain")
 	_, ok := result.(*openAI)
@@ -30,7 +33,7 @@ func TestNew_WithOpenAIProvider_ReturnsOpenAIBrain(t *testing.T) {
 }
 
 func TestNew_MockProviderNoPlaybook_ReturnsMockInstance(t *testing.T) {
-	result, err := New(mock, "test-token", "qwen", system)
+	result, err := New(mock, address, "test-token", "qwen", system)
 
 	require.NoError(t, err)
 	_, ok := result.(*mockBrain)
@@ -38,9 +41,34 @@ func TestNew_MockProviderNoPlaybook_ReturnsMockInstance(t *testing.T) {
 }
 
 func TestNew_UnknownProvider_ReturnsError(t *testing.T) {
-	b, err := New("unknown", "test-token", "deepseek", system)
+	b, err := New("unknown", address, "test-token", "deepseek", system)
 
 	require.Error(t, err)
 	assert.Nil(t, b)
 	assert.Contains(t, err.Error(), "unknown provider: unknown")
+}
+
+func TestNew_CustomProvider_ReturnsCustomInstance(t *testing.T) {
+	b, err := New(custom, address, "custom-token", "custom-model", system)
+
+	require.NoError(t, err)
+	assert.NotNil(t, b)
+	_, ok := b.(*openAI)
+	require.True(t, ok, "Expected result to be OpenAI compatible instance")
+}
+
+func TestNew_CutomProviderMissingURL_ReturnsError(t *testing.T) {
+	b, err := New(custom, "", "custom-token", "custom-model", system)
+
+	require.Error(t, err)
+	assert.Nil(t, b)
+	require.Contains(t, err.Error(), "custom provider requires a URL")
+}
+
+func TestNew_CustomProviderMissingModel_ReturnsError(t *testing.T) {
+	b, err := New(custom, address, "custom-token", "", system)
+
+	require.Error(t, err)
+	assert.Nil(t, b)
+	require.Contains(t, err.Error(), "custom provider requires a model")
 }

--- a/internal/brain/custom.go
+++ b/internal/brain/custom.go
@@ -1,0 +1,5 @@
+package brain
+
+func NewCustom(token, url, model, system string) (Brain, error) {
+	return NewOpenAI(token, url, model, system)
+}

--- a/internal/brain/custom_test.go
+++ b/internal/brain/custom_test.go
@@ -1,0 +1,21 @@
+package brain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCustom(t *testing.T) {
+	token := "test_token"
+	url := "http://test_url.com/v1/chat/completions"
+	model := "test_model"
+	system := "test_system"
+	custom, err := NewCustom(token, url, model, system)
+	require.NoError(t, err)
+	assert.NotNil(t, custom)
+	expected, err := NewOpenAI(token, url, model, system)
+	require.NoError(t, err)
+	assert.Equal(t, expected, custom)
+}

--- a/internal/brain/deepseek.go
+++ b/internal/brain/deepseek.go
@@ -43,7 +43,7 @@ type deepseekMsg struct {
 func NewDeepSeek(apiKey, _ string) Brain {
 	return &deepSeek{
 		token: apiKey,
-		url:   "https://api.deepseek.com/chat/completions",
+		url:   "https://api.deepseek.com/v1/chat/completions",
 		model: "deepseek-chat",
 	}
 }

--- a/internal/brain/openai.go
+++ b/internal/brain/openai.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/cqfn/refrax/internal/log"
 )
 
 // OpenAI represents a client for interacting with the OpenAI API
@@ -19,8 +21,10 @@ type openAI struct {
 }
 
 type openaiReq struct {
-	Model    string      `json:"model"`
-	Messages []openaiMsg `json:"messages"`
+	Model       string      `json:"model"`
+	Messages    []openaiMsg `json:"messages"`
+	Stream      bool        `json:"stream"`
+	Temperature *float64    `json:"temperature,omitempty"`
 }
 
 type openaiResp struct {
@@ -36,14 +40,23 @@ type openaiMsg struct {
 	Content string `json:"content"`
 }
 
-// NewOpenAI creates a new OpenAI instance
-func NewOpenAI(apiKey, system string) Brain {
-	return &openAI{
-		token:  apiKey,
-		url:    "https://api.openai.com/v1/chat/completions",
-		model:  "gpt-3.5-turbo", // Default model
-		system: system,
+// NewOpenAIDefault creates a new OpenAI instance with default settings
+func NewOpenAIDefault(token, system string) (Brain, error) {
+	return NewOpenAI(token, "https://api.openai.com/v1/chat/completions", "gpt-3.5-turbo", system)
+}
+
+// NewOpenAI creates a new OpenAI instance with the provided settings
+func NewOpenAI(token, url, model, system string) (Brain, error) {
+	err := verifyUrl(url)
+	if err != nil {
+		return nil, err
 	}
+	return &openAI{
+		token:  token,
+		url:    url,
+		model:  model,
+		system: system,
+	}, nil
 }
 
 // Ask sends a question to the OpenAI API
@@ -52,12 +65,16 @@ func (o *openAI) Ask(question string) (string, error) {
 }
 
 func (o *openAI) send(system, user string) (answer string, err error) {
+	log.Debug("sending request to '%s', model '%s', and prompt: '%s'", o.url, o.model, user)
+	temp := float64(0.0)
 	body := openaiReq{
 		Model: o.model,
 		Messages: []openaiMsg{
 			{Role: "system", Content: system},
 			{Role: "user", Content: strings.TrimSpace(user)},
 		},
+		Stream:      false,
+		Temperature: &temp,
 	}
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -68,7 +85,7 @@ func (o *openAI) send(system, user string) (answer string, err error) {
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+o.token)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", o.token))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("API request failed: %w", err)
@@ -80,7 +97,7 @@ func (o *openAI) send(system, user string) (answer string, err error) {
 	}()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("API error: %s", body)
+		return "", fmt.Errorf("API error (code: %d): %s", resp.StatusCode, body)
 	}
 	var response openaiResp
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
@@ -90,4 +107,14 @@ func (o *openAI) send(system, user string) (answer string, err error) {
 		return "", errors.New("no choices in response")
 	}
 	return response.Choices[0].Message.Content, nil
+}
+
+func verifyUrl(url string) error {
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("invalid URL: must start with http:// or https://")
+	}
+	if !strings.HasSuffix(url, "/v1/chat/completions") {
+		return fmt.Errorf("invalid URL: must end with /v1/chat/completions")
+	}
+	return nil
 }

--- a/internal/brain/openai_test.go
+++ b/internal/brain/openai_test.go
@@ -3,6 +3,7 @@ package brain
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -10,7 +11,8 @@ func TestOpenAI_Ask_PositiveCase(t *testing.T) {
 	server := NewEchoServer(t, "gpt-3.5-turbo", "test_api_key")
 	defer server.Close()
 
-	openai := NewOpenAI("test_api_key", "openai sys prompt")
+	openai, err := NewOpenAIDefault("test_api_key", "openai sys prompt")
+	require.NoError(t, err)
 	openai.(*openAI).url = server.URL
 
 	answer, err := openai.Ask("This is a test question")
@@ -23,11 +25,28 @@ func TestOpenAI_Ask_NegativeCase(t *testing.T) {
 	server := NewErrorServer(t)
 	defer server.Close()
 
-	openai := NewOpenAI("test_api_key", "openai system prompt")
+	openai, err := NewOpenAIDefault("test_api_key", "openai system prompt")
+	require.NoError(t, err)
 	openai.(*openAI).url = server.URL
 
 	answer, err := openai.Ask("This is a test question")
 
 	require.Error(t, err)
 	require.Empty(t, answer)
+}
+
+func TestOpenAI_WrongUrlPrefix(t *testing.T) {
+	brain, err := NewOpenAI("token:", "ftp://invalid-url.com", "model", "system")
+
+	assert.Nil(t, brain)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must start with http:// or https://")
+}
+
+func TestOpenAI_Ask_EmptyResponse(t *testing.T) {
+	brain, err := NewOpenAI("token", "http://invalid-url.com", "model", "system")
+
+	assert.Nil(t, brain)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must end with /v1/chat/completions")
 }

--- a/internal/client/params.go
+++ b/internal/client/params.go
@@ -5,6 +5,7 @@ import "io"
 // Params holds the configuration parameters for Refrax commands.
 type Params struct {
 	Provider    string
+	ProviderUrl string
 	Token       string
 	Playbook    string
 	MockProject bool

--- a/internal/client/refrax_client.go
+++ b/internal/client/refrax_client.go
@@ -305,7 +305,7 @@ func printStats(p Params, s ...*stats.Stats) error {
 }
 
 func mind(p Params, token, model string, system *prompts.System, s *stats.Stats) (brain.Brain, error) {
-	ai, err := brain.New(p.Provider, token, model, system.String(), p.Playbook)
+	ai, err := brain.New(p.Provider, p.ProviderUrl, token, model, system.String(), p.Playbook)
 	if p.Stats {
 		ai = brain.NewMetricBrain(ai, s)
 	}


### PR DESCRIPTION
This PR adds a `custom` provider to `refrax`, enabling integration with custom AI models.

Related to #136